### PR TITLE
chore: Spring Security 종속 삭제 및 개발을 위한 기본 package setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.modulith:spring-modulith-starter-core'
@@ -44,7 +43,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.modulith:spring-modulith-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/leisureup/global/package-info.java
+++ b/src/main/java/org/leisureup/global/package-info.java
@@ -1,0 +1,5 @@
+@ApplicationModule(type = Type.OPEN)
+package org.leisureup.global;
+
+import org.springframework.modulith.*;
+import org.springframework.modulith.ApplicationModule.*;

--- a/src/main/java/org/leisureup/location/internal/controller/LocationController.java
+++ b/src/main/java/org/leisureup/location/internal/controller/LocationController.java
@@ -1,0 +1,8 @@
+package org.leisureup.location.internal.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class LocationController {
+
+}

--- a/src/main/java/org/leisureup/location/spi/package-info.java
+++ b/src/main/java/org/leisureup/location/spi/package-info.java
@@ -1,0 +1,4 @@
+@NamedInterface(name = "spi")
+package org.leisureup.location.spi;
+
+import org.springframework.modulith.*;

--- a/src/main/java/org/leisureup/map/internal/controller/MapController.java
+++ b/src/main/java/org/leisureup/map/internal/controller/MapController.java
@@ -1,0 +1,8 @@
+package org.leisureup.map.internal.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class MapController {
+
+}

--- a/src/main/java/org/leisureup/map/spi/package-info.java
+++ b/src/main/java/org/leisureup/map/spi/package-info.java
@@ -1,0 +1,4 @@
+@NamedInterface(name = "spi")
+package org.leisureup.map.spi;
+
+import org.springframework.modulith.*;

--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -1,0 +1,8 @@
+package org.leisureup.member.internal.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class MemberController {
+
+}

--- a/src/main/java/org/leisureup/member/spi/package-info.java
+++ b/src/main/java/org/leisureup/member/spi/package-info.java
@@ -1,0 +1,4 @@
+@NamedInterface(name = "spi")
+package org.leisureup.member.spi;
+
+import org.springframework.modulith.*;

--- a/src/main/java/org/leisureup/travel/internal/controller/TravelController.java
+++ b/src/main/java/org/leisureup/travel/internal/controller/TravelController.java
@@ -1,0 +1,8 @@
+package org.leisureup.travel.internal.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class TravelController {
+
+}

--- a/src/main/java/org/leisureup/travel/spi/package-info.java
+++ b/src/main/java/org/leisureup/travel/spi/package-info.java
@@ -1,0 +1,4 @@
+@NamedInterface(name = "spi")
+package org.leisureup.travel.spi;
+
+import org.springframework.modulith.*;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`none`

## 📝작업 내용

1. Spring Security 종속성을 삭제했습니다.
2. Spring Modulith 개발을 위한 기본 Domain package 들을 구성했습니다.

## 💬 리뷰 요구사항 (선택)

`none`