### PR TITLE
cd: cd pipeline 구성

### DIFF
--- a/.github/workflows/cd-prod.yaml
+++ b/.github/workflows/cd-prod.yaml
@@ -1,0 +1,55 @@
+name: CD prod
+
+on:
+  push:
+    branches:
+      - prod
+
+permissions:
+  contents: read
+  issues: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  run-test-for-validation:
+    uses: ./.github/workflows/run-test.yaml
+    with:
+      comment-test-result: false
+
+  push-image:
+    needs: run-test-for-validation
+    uses: ./.github/workflows/push-docker-image.yaml
+    with:
+      tags: "${{ github.ref_name }}-${{ github.sha }}"
+    secrets:
+      docker-hub-id: ${{ secrets.DOCKER_HUB_ID }}
+      docker-hub-pw: ${{ secrets.DOCKER_HUB_PW }}
+      common-secret: ${{ secrets.COMMON_SECRET }}
+      prod-secret: ${{ secrets.PROD_SECRET }}
+      staging-secret: ${{ secrets.STAGING_SECRET }}
+
+  down-application:
+    needs: run-test-for-validation
+    uses: ./.github/workflows/down-application.yaml
+    with:
+      compose-file-name: 'docker-compose.prod.yaml'
+    secrets:
+      server-address: ${{ secrets.PROD_SERVER_ADDRESS }}
+      server-id: ${{ secrets.PROD_SERVER_ID }}
+      serve-key: ${{ secrets.PROD_SERVER_KEY }}
+
+  up-application:
+    needs:
+      - push-image
+      - down-application
+    uses: ./.github/workflows/up-application.yaml
+    with:
+      compose-file-name: 'docker-compose.prod.yaml'
+      image-tag: "${{ github.ref_name }}-${{ github.sha }}"
+    secrets:
+      server-address: ${{ secrets.PROD_SERVER_ADDRESS }}
+      server-id: ${{ secrets.PROD_SERVER_ID }}
+      serve-key: ${{ secrets.PROD_SERVER_KEY }}
+      docker-hub-id: ${{ secrets.DOCKER_HUB_ID }}
+      docker-hub-pw: ${{ secrets.DOCKER_HUB_PW }}

--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -1,0 +1,55 @@
+name: CD staging
+
+on:
+  push:
+    branches:
+      - staging
+
+permissions:
+  contents: read
+  issues: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  run-test-for-validation:
+    uses: ./.github/workflows/run-test.yaml
+    with:
+      comment-test-result: false
+
+  push-image:
+    needs: run-test-for-validation
+    uses: ./.github/workflows/push-docker-image.yaml
+    with:
+      tags: "${{ github.ref_name }}-${{ github.sha }}"
+    secrets:
+      docker-hub-id: ${{ secrets.DOCKER_HUB_ID }}
+      docker-hub-pw: ${{ secrets.DOCKER_HUB_PW }}
+      common-secret: ${{ secrets.COMMON_SECRET }}
+      prod-secret: ${{ secrets.PROD_SECRET }}
+      staging-secret: ${{ secrets.STAGING_SECRET }}
+
+  down-application:
+    needs: run-test-for-validation
+    uses: ./.github/workflows/down-application.yaml
+    with:
+      compose-file-name: 'docker-compose.staging.yaml'
+    secrets:
+      server-address: ${{ secrets.STAGING_SERVER_ADDRESS }}
+      server-id: ${{ secrets.STAGING_SERVER_ID }}
+      serve-key: ${{ secrets.STAGING_SERVER_KEY }}
+
+  up-application:
+    needs:
+      - push-image
+      - down-application
+    uses: ./.github/workflows/up-application.yaml
+    with:
+      compose-file-name: 'docker-compose.staging.yaml'
+      image-tag: "${{ github.ref_name }}-${{ github.sha }}"
+    secrets:
+      server-address: ${{ secrets.STAGING_SERVER_ADDRESS }}
+      server-id: ${{ secrets.STAGING_SERVER_ID }}
+      serve-key: ${{ secrets.STAGING_SERVER_KEY }}
+      docker-hub-id: ${{ secrets.DOCKER_HUB_ID }}
+      docker-hub-pw: ${{ secrets.DOCKER_HUB_PW }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,31 +16,6 @@ on:
 
 jobs:
   run-and-report-test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Build application
-        uses: ./.github/workflows/composite/utils/build-application
-        with:
-          java_version: '21'
-
-      - name: Run test
-        continue-on-error: true
-        id: test
-        shell: bash
-        run: |
-          ./gradlew test --build-cache --parallel
-
-      - name: Add test result as comment
-        if: always()
-        continue-on-error: true
-        uses: EnricoMi/publish-unit-test-result-action@v2.19.0
-        with:
-          files: ./build/test-results/**/*.xml
-
-      - name: Abort on test fail
-        if: steps.test.outcome != 'success'
-        run: exit 1;
+    uses: ./.github/workflows/run-test.yaml
+    with:
+      comment-test-result: true

--- a/.github/workflows/composite/utils/save-to-file/action.yaml
+++ b/.github/workflows/composite/utils/save-to-file/action.yaml
@@ -1,0 +1,37 @@
+name: Save to file
+
+description: 'Save given context to file.'
+
+inputs:
+  context:
+    required: true
+    description: 'A context to be saved as a file'
+
+  file_dir:
+    required: true
+    description: 'A directory where file will exist'
+
+  file_name:
+    required: true
+    description: 'Name of the file to be saved'
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: Check whether duplicate exists
+      shell: bash
+      run: |
+        if [ -f "${{ inputs.file_dir }}/${{ inputs.file_name }}" ]; then
+          exit 1
+        fi
+
+    - name: Create directory if not exists
+      shell: bash
+      run: |
+        mkdir -p "${{ inputs.file_dir }}"
+
+    - name: Save context to destination
+      shell: bash
+      run: |
+        echo "${{ inputs.context }}" > "${{ inputs.file_dir }}/${{ inputs.file_name }}"

--- a/.github/workflows/composite/utils/setup-all-secrets/action.yaml
+++ b/.github/workflows/composite/utils/setup-all-secrets/action.yaml
@@ -1,0 +1,41 @@
+name: Setup all secrets
+
+description: 'Setup all secret property profiles'
+
+inputs:
+  common-secret-context:
+    required: true
+    description: 'Common secret property context'
+
+  prod-secret-context:
+    required: true
+    description: 'Production secret property context'
+
+  staging-secret-context:
+    required: true
+    description: 'Staging secret property context'
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: Setup common secret
+      uses: ./.github/workflows/composite/utils/save-to-file
+      with:
+        context: ${{ inputs.common-secret-context }}
+        file_dir: 'src/main/resources'
+        file_name: 'application-common-secret.yaml'
+
+    - name: Setup prod secret
+      uses: ./.github/workflows/composite/utils/save-to-file
+      with:
+        context: ${{ inputs.prod-secret-context }}
+        file_dir: 'src/main/resources'
+        file_name: 'application-prod-secret.yaml'
+
+    - name: Setup staging secret
+      uses: ./.github/workflows/composite/utils/save-to-file
+      with:
+        context: ${{ inputs.staging-secret-context }}
+        file_dir: 'src/main/resources'
+        file_name: 'application-staging-secret.yaml'

--- a/.github/workflows/down-application.yaml
+++ b/.github/workflows/down-application.yaml
@@ -1,0 +1,45 @@
+name: Down application
+
+on:
+  workflow_call:
+    inputs:
+      compose-file-name:
+        required: true
+        type: string
+        description: 'Name of a docker-compose file in server to down application'
+
+    secrets:
+      server-address:
+        required: true
+        description: 'An address of server'
+
+      server-id:
+        required: true
+        description: 'SSH user'
+
+      serve-key:
+        required: true
+        description: 'SSH key'
+
+jobs:
+  down-application:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Down composed containers
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.server-address }}
+          username: ${{ secrets.server-id }}
+          key: ${{ secrets.serve-key }}
+          script: |
+            docker compose -f "${{ inputs.compose-file-name }}" down || true
+
+      - name: Prune images
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.server-address }}
+          username: ${{ secrets.server-id }}
+          key: ${{ secrets.serve-key }}
+          script: |
+            docker image prune -af || true

--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -1,0 +1,102 @@
+name: Push docker image
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        required: true
+        type: string
+        description: 'List of tags to be added on image'
+        default: '${{ github.ref_name }}-${{ github.sha }}'
+
+      platforms:
+        required: false
+        type: string
+        default: 'linux/amd64'
+        description: 'A platform that image runnable'
+
+      dockerfile-dir:
+        required: false
+        type: string
+        default: '.'
+        description: 'A directory where .dockerfile exists'
+
+      dockerfile-name:
+        required: false
+        type: string
+        default: 'application.dockerfile'
+        description: 'A name of a dockerfile'
+
+    secrets:
+      docker-hub-id:
+        required: true
+        description: 'DockerHub ID'
+
+      docker-hub-pw:
+        required: true
+        description: 'DockerHub PW'
+
+      common-secret:
+        required: true
+        description: 'COMMON_SECRET'
+
+      prod-secret:
+        required: true
+        description: 'PROD_SECRET'
+
+      staging-secret:
+        required: true
+        description: 'STAGING_SECRET'
+
+env:
+  image-name: 'waymakers/leisureupbe'
+  image-tags: ${{ inputs.tags }}
+  image-plts: ${{ inputs.platforms }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup secrets
+        uses: ./.github/workflows/composite/utils/setup-all-secrets
+        with:
+          common-secret-context: ${{ secrets.common-secret }}
+          prod-secret-context: ${{ secrets.prod-secret }}
+          staging-secret-context: ${{ secrets.staging-secret }}
+
+      - name: Build application
+        uses: ./.github/workflows/composite/utils/build-application
+
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ env.image-plts }}
+
+      - name: DockerHub login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.docker-hub-id }}
+          password: ${{ secrets.docker-hub-pw }}
+          logout: 'true'
+
+      - name: Create metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.image-name }}
+          tags: ${{ env.image-tags }}
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.dockerfile-dir }}
+          file: ${{ inputs.dockerfile-name }}
+          push: 'true'
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: ${{ env.image-plts }}

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -1,0 +1,55 @@
+name: Run test
+
+# Required permission for test result comment
+permissions:
+  contents: read
+  issues: read
+  checks: write
+  pull-requests: write
+
+on:
+  workflow_call:
+    inputs:
+      comment-test-result:
+        required: true
+        type: boolean
+        description: 'Add test result comment in triggered pull request'
+        default: false
+
+env:
+  redis-port: '6379'
+
+jobs:
+  run-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build application
+        uses: ./.github/workflows/composite/utils/build-application
+
+      - name: Setup redis
+        uses: supercharge/redis-github-action@1.8.0
+        with:
+          redis-version: 'latest'
+          redis-port: ${{ env.redis-port }}
+
+      - name: Run test
+        continue-on-error: true
+        id: test
+        shell: bash
+        run: |
+          ./gradlew test --build-cache --parallel
+
+      - name: Add test result as comment
+        if: ${{ inputs.comment-test-result }}
+        continue-on-error: true
+        uses: EnricoMi/publish-unit-test-result-action@v2.19.0
+        with:
+          files: ./build/test-results/**/*.xml
+
+      - name: Abort on test fail
+        if: steps.test.outcome != 'success'
+        run: exit 1;

--- a/.github/workflows/up-application.yaml
+++ b/.github/workflows/up-application.yaml
@@ -1,0 +1,80 @@
+name: Up application
+
+on:
+  workflow_call:
+    inputs:
+      compose-file-name:
+        required: true
+        type: string
+        description: 'Name of a docker-compose file in server to up application'
+
+      image-tag:
+        required: true
+        type: string
+        description: 'Tag of an image to pull'
+
+    secrets:
+      server-address:
+        required: true
+        description: 'An address of server'
+
+      server-id:
+        required: true
+        description: 'SSH user'
+
+      serve-key:
+        required: true
+        description: 'SSH key'
+
+      docker-hub-id:
+        required: true
+        description: 'DockerHub ID'
+
+      docker-hub-pw:
+        required: true
+        description: 'DockerHub PW'
+
+env:
+  image-to-pull: 'waymakers/leisureupbe:${{ inputs.image-tag }}'
+  compose-file: ${{ inputs.compose-file-name }}
+  IMAGE_TAG: ${{ inputs.image-tag }}
+
+jobs:
+  up-application:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pull docker image
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.server-address }}
+          username: ${{ secrets.server-id }}
+          key: ${{ secrets.serve-key }}
+          script: |
+            echo ${{ secrets.docker-hub-pw }} | \
+            docker login -u ${{ secrets.docker-hub-id }} --password-stdin
+            docker pull ${{ env.image-to-pull }}
+            docker logout
+
+      - name: Copy compose
+        uses: appleboy/scp-action@v1.0.0
+        with:
+          host: ${{ secrets.server-address }}
+          username: ${{ secrets.server-id }}
+          key: ${{ secrets.serve-key }}
+          overwrite: true
+          source: ${{ env.compose-file }}
+          target: '/home/${{ secrets.server-id }}'
+
+      - name: Compose application
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.server-address }}
+          username: ${{ secrets.server-id }}
+          key: ${{ secrets.serve-key }}
+          envs: IMAGE_TAG
+          script: |
+            docker compose -f ${{ env.compose-file }} up -d

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+### Dev or Secret Stuffs ###
+
+.local/
+src/main/resources/application-common-secret.yaml
+src/main/resources/application-prod-secret.yaml
+src/main/resources/application-staging-secret.yaml
+
 HELP.md
 .gradle
 build/

--- a/application.dockerfile
+++ b/application.dockerfile
@@ -1,0 +1,6 @@
+
+FROM openjdk:21
+WORKDIR /LeisureUp-BE
+ARG JAR_FILE=build/libs/LeisureUp-BE-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} application.jar
+ENTRYPOINT ["java", "-jar", "/LeisureUp-BE/application.jar"]

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,0 +1,27 @@
+name: local-dev-compose
+
+services:
+  mysql:
+    container_name: mysql
+    image: mysql
+
+    ports:
+      - "3306:3306"
+
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: db-local
+      TZ: 'Asia/Seoul'
+
+    volumes:
+      - ./.local/.mysql:/var/lib/mysql
+
+    restart: on-failure
+
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - "6379:6379"
+
+    restart: on-failure

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,30 @@
+name: prod-compose
+
+services:
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - "6379:6379"
+
+    restart: on-failure
+    networks:
+      - LeisureUpBE-net
+
+  application:
+    container_name: application
+    image: waymakers/leisureupbe:${IMAGE_TAG}
+
+    ports:
+      - "8080:8080"
+
+    environment:
+      - "SPRING_PROFILES_ACTIVE=prod"
+
+    depends_on:
+      - redis
+    networks:
+      - LeisureUpBE-net
+
+networks:
+  LeisureUpBE-net: { }

--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -1,0 +1,30 @@
+name: staging-compose
+
+services:
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - "6379:6379"
+
+    restart: on-failure
+    networks:
+      - LeisureUpBE-net
+
+  application:
+    container_name: application
+    image: waymakers/leisureupbe:${IMAGE_TAG}
+
+    ports:
+      - "8080:8080"
+
+    environment:
+      - "SPRING_PROFILES_ACTIVE=staging"
+
+    depends_on:
+      - redis
+    networks:
+      - LeisureUpBE-net
+
+networks:
+  LeisureUpBE-net: { }

--- a/src/main/resources/application-local-secret.yaml
+++ b/src/main/resources/application-local-secret.yaml
@@ -1,0 +1,6 @@
+db:
+  url: jdbc:mysql://localhost:3306/db-local
+  username: root
+  password: root
+
+spring.jpa.hibernate.ddl-auto: create

--- a/src/main/resources/application-local-secret.yaml
+++ b/src/main/resources/application-local-secret.yaml
@@ -1,6 +1,9 @@
 db:
-  url: jdbc:mysql://localhost:3306/db-local
+  host: localhost
   username: root
   password: root
+  name: db-local
+  port: 3306
+  url: jdbc:mysql://${db.host}:${db.port}/${db.name}
 
 spring.jpa.hibernate.ddl-auto: create

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,11 +1,41 @@
 spring:
-  application:
-    name: LeisureUp-BE
+  application.name: LeisureUp-BE
+  threads.virtual.enabled: true
+
+  profiles:
+    default: local
+    group:
+      local:
+        - common-secret
+        - local-secret
+      staging:
+        - common-secret
+        - staging-secret
+      prod:
+        - common-secret
+        - prod-secret
+
+  datasource:
+    url: ${db.url}
+    username: ${db.username}
+    password: ${db.password}
 
   jpa:
     open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
 
-  threads:
-    virtual:
-      enabled: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
 
+logging:
+  level:
+    org.hibernate.SQL: debug
+  pattern:
+    dateformat: yyyy-MM-dd'T'HH:mm:ss.SSSz,Asia/Seoul

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,12 +1,24 @@
 spring:
-  application:
-    name: LeisureUp-BE
+  application.name: LeisureUp-BE
+  threads.virtual.enabled: true
 
   datasource:
     url: jdbc:h2:mem:test
 
-  threads:
-    virtual:
-      enabled: true
   jpa:
     open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
+
+logging:
+  level:
+    org.hibernate.SQL: debug


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`none`

## 📝작업 내용

1. CI 수행 시 redis 를 사용할 수 있도록 수정했습니다.
2. `prod`, `staging` branch 에 대한 CD 파이프라인을 구성했습니다.

<details><summary> CD 파이프라인 동작 흐름</summary>

CD 파이프라인은 총 4 가지 jobs 로 구성됩니다. 

1. 테스트 실행 (run-test)
2. 서버에 실행중인 docker 종료 (down-application)
3. DockerHub 에 image 를 push (push-image)
4. 서버에 docker image 를 받은 후 `docker compose` 실행 (up-application)

각 job 들의 상관관계와 실행 순서는 아래 그림과 같습니다.

![캡처](https://github.com/user-attachments/assets/4006e746-b40e-4272-9ef9-9191fe9b94ae)

한 배포에 걸리는 시간은 어림잡아 5 분 되는 것 같습니다.

</details>

<details><summary> 프로필 설정 (.yaml 파일) 설명</summary>

현재 `.gitignore` 로 다음 3 가지 `.yaml` 파일이 ignore 된 상태입니다.

- `application-common-secret.yaml` : 공용 비밀 저장용 프로필
- `application-prod-secret.yaml` : production 비밀 저장용 프로필
- `application-staging-secret.yaml` : staging 비밀 저장용 프로필

### 1. `common-secret` 프로필

`common-secret` 프로필은 비밀로 취급해야 하지만 `prod`, `staging` 등의 프로필에서 공통적으로 사용할 수 있는 비밀을 명시합니다.
JWT 의 signature, OAuth2 의 발급 key 들이 이들에 해당될 수 있습니다.

```yaml
# application-common-secret.yaml (example)

secret:
  jwt:
    access-token:
      key: key-signature-of-access-token
      expiration: 30
    refresh-token:
      key: key-signature-of-refresh-token
      expiration: 30

  oauth:
    google.key: this-is-google-oauth-key
    kako.key: this-is-kakao-oauth-key
    apple.key: this-is-apple-oauth-key
```


### 2. `prod-secret`, `staging-secret` 프로필

반면 `prod-secret`, `staging-secret` 은 각 서버에 특화된 비밀을 명시합니다. 
이들의 기본 양식은 `application-local-secret.yaml` 과 동일하며, 이는 아래와 같습니다.

```yaml
# application-local-secret.yaml

db:
  host: localhost
  username: root
  password: root
  name: db-local
  port: 3306
  url: jdbc:mysql://${db.host}:${db.port}/${db.name}

spring.jpa.hibernate.ddl-auto: create
```

비밀에 포함된 내용은 datasource url 등이 될 수 있습니다.

</details>

## 💬 리뷰 요구사항 (선택)

`none`