### PR TITLE
Feat/location - `location` 도메인 관련 entity, 기본 구조 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springframework.modulith:spring-modulith-starter-core'
     implementation 'org.springframework.modulith:spring-modulith-starter-jpa'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/org/leisureup/LeisureUp.java
+++ b/src/main/java/org/leisureup/LeisureUp.java
@@ -2,8 +2,10 @@ package org.leisureup;
 
 import org.springframework.boot.*;
 import org.springframework.boot.autoconfigure.*;
-import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.*;
+import org.springframework.data.jpa.repository.config.*;
 
+@EnableJpaAuditing
 @SpringBootApplication
 @EnableFeignClients(basePackages = "org.leisureup")
 public class LeisureUp {

--- a/src/main/java/org/leisureup/global/config/SwaggerConfig.java
+++ b/src/main/java/org/leisureup/global/config/SwaggerConfig.java
@@ -1,0 +1,46 @@
+package org.leisureup.global.config;
+
+import io.swagger.v3.oas.models.*;
+import io.swagger.v3.oas.models.info.*;
+import io.swagger.v3.oas.models.security.*;
+import org.springframework.context.annotation.*;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI swagger() {
+        return new OpenAPI()
+                .components(components())
+                .info(info())
+                .addSecurityItem(
+                        new SecurityRequirement().addList("Authorization")
+                );
+    }
+
+    @Bean
+    public Components components() {
+        return new Components()
+                .addSecuritySchemes(
+                        "Authorization", jwtSecurityScheme()
+                );
+    }
+
+    @Bean
+    public SecurityScheme jwtSecurityScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+    }
+
+    @Bean
+    public Info info() {
+        return new Info()
+                .title("LeisureUp - backend")
+                .version("v1")
+                .description("API specification for LeisureUp backend application");
+    }
+}

--- a/src/main/java/org/leisureup/global/exception/CustomException.java
+++ b/src/main/java/org/leisureup/global/exception/CustomException.java
@@ -1,0 +1,15 @@
+package org.leisureup.global.exception;
+
+import lombok.*;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final int code;
+    private final String message;
+
+    protected CustomException(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/leisureup/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/leisureup/global/exception/GlobalExceptionHandler.java
@@ -1,13 +1,16 @@
 package org.leisureup.global.exception;
 
-import org.leisureup.global.response.ApiResponse;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.leisureup.global.response.*;
+import org.springframework.web.bind.annotation.*;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(NotFound.class)
-    public ApiResponse<?> notFound(NotFound e) {
-        return ApiResponse.failure(e.getMessage());
+
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse<?> customException(CustomException e) {
+        int code = e.getCode();
+        String message = e.getMessage();
+        return ApiResponse.failure(code, message);
     }
+
 }

--- a/src/main/java/org/leisureup/global/exception/NotFound.java
+++ b/src/main/java/org/leisureup/global/exception/NotFound.java
@@ -1,7 +1,8 @@
 package org.leisureup.global.exception;
 
-public class NotFound extends RuntimeException {
+public class NotFound extends CustomException {
+
     public NotFound(String explanation) {
-        super(explanation);
+        super(404, explanation);
     }
 }

--- a/src/main/java/org/leisureup/global/exception/NotImplemented.java
+++ b/src/main/java/org/leisureup/global/exception/NotImplemented.java
@@ -1,0 +1,14 @@
+package org.leisureup.global.exception;
+
+public class NotImplemented extends CustomException {
+
+    private static final String defaultMessage = "Not implemented";
+
+    public NotImplemented() {
+        super(500, defaultMessage);
+    }
+
+    public NotImplemented(String message) {
+        super(500, message);
+    }
+}

--- a/src/main/java/org/leisureup/global/response/ApiResponse.java
+++ b/src/main/java/org/leisureup/global/response/ApiResponse.java
@@ -1,22 +1,21 @@
 package org.leisureup.global.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ApiResponse<T> {
-    private boolean success;
-    private T data;
-    private String message;
 
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, data, null);
+    private final boolean success;
+    private final int code;
+    private final T data;
+    private final String message;
+
+    public static <T> ApiResponse<T> success(int code, T data) {
+        return new ApiResponse<>(true, code, data, null);
     }
 
-    public static <T> ApiResponse<T> failure(String message) {
-        return new ApiResponse<>(false, null, message);
+    public static <T> ApiResponse<T> failure(int code, String message) {
+        return new ApiResponse<>(false, code, null, message);
     }
 }

--- a/src/main/java/org/leisureup/global/response/ResponseWrapper.java
+++ b/src/main/java/org/leisureup/global/response/ResponseWrapper.java
@@ -1,0 +1,45 @@
+package org.leisureup.global.response;
+
+import lombok.extern.slf4j.*;
+import org.springframework.core.*;
+import org.springframework.http.*;
+import org.springframework.http.converter.*;
+import org.springframework.http.server.*;
+import org.springframework.lang.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.*;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "org.leisureup")
+public class ResponseWrapper implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(
+            @NonNull MethodParameter returnType,
+            @NonNull Class<? extends HttpMessageConverter<?>> converterType
+    ) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body, @NonNull MethodParameter returnType,
+            @NonNull MediaType selectedContentType,
+            @NonNull Class<? extends HttpMessageConverter<?>> selectedConverterType,
+            @NonNull ServerHttpRequest request, @NonNull ServerHttpResponse response
+    ) {
+
+        if (body instanceof ApiResponse<?> api) {
+            int code = api.getCode();
+            HttpStatusCode httpStatusCode = HttpStatus.valueOf(code);
+            response.setStatusCode(httpStatusCode);
+        } else {
+            log.warn(
+                    "Incompatible response type encountered: {}",
+                    body.getClass().getSimpleName()
+            );
+        }
+
+        return body;
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/controller/LocationController.java
+++ b/src/main/java/org/leisureup/location/internal/controller/LocationController.java
@@ -1,8 +1,26 @@
 package org.leisureup.location.internal.controller;
 
+import jakarta.validation.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+import org.leisureup.global.response.*;
+import org.leisureup.location.internal.dto.response.*;
+import org.leisureup.location.internal.service.*;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/locations")
+@RequiredArgsConstructor
 public class LocationController {
+
+    private final LocationService locationService;
+
+    @GetMapping("/{id}")
+    public ApiResponse<GetLocationResponse> getLocation(
+            @Valid @Positive @NotNull
+            @PathVariable Long id
+    ) {
+        return ApiResponse.success(200, locationService.getLocation(id));
+    }
 
 }

--- a/src/main/java/org/leisureup/location/internal/domain/Address.java
+++ b/src/main/java/org/leisureup/location/internal/domain/Address.java
@@ -1,0 +1,48 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Location 주소
+ * <li>장소마다 {@code briefedAddress} 의 표현 형식이 다를 수 있음.</li>
+ * <li>{@code detailedAddress} 가 없는 장소도 있을 수 있음.</li>
+ */
+@Getter
+@Setter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+
+    /**
+     * 간단한 주소
+     * <p>
+     * {@code Ex) 서울특별시 종로구 누상동}
+     */
+    @Column(length = 500)
+    private String briefedAddress;
+
+    /**
+     * 상세 주소
+     * <p>
+     * {@code Ex) 산1-29번지 외}
+     */
+    @Column(length = 100)
+    private String detailedAddress;
+
+    /**
+     * 우편번호 {@code Ex) "03038"}
+     */
+    @Column(length = 16)
+    private String zipcode;
+
+    public static Address of(String briefedAddress,
+            String detailedAddress, String zipcode) {
+        return new Address(briefedAddress, detailedAddress, zipcode);
+    }
+
+    public static Address of(Address address) {
+        return of(address.getBriefedAddress(), address.getDetailedAddress(), address.getZipcode());
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/CatEarth.java
+++ b/src/main/java/org/leisureup/location/internal/domain/CatEarth.java
@@ -1,0 +1,29 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 땅 타입 카테고리
+ */
+@Getter
+@Entity
+@DiscriminatorValue(CatEarth.TYPE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CatEarth extends Category {
+
+    public static final String TYPE = "EARTH";
+
+    private CatEarth(String name, String categoryCode) {
+        super(name, categoryCode);
+    }
+
+    public static CatEarth of(String name, String code) {
+        return new CatEarth(name, code);
+    }
+
+    @Override
+    public String getCategoryType() {
+        return TYPE;
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/CatOther.java
+++ b/src/main/java/org/leisureup/location/internal/domain/CatOther.java
@@ -1,0 +1,29 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 땅, 하늘, 물 타입 카테고리 외 나머지
+ */
+@Getter
+@Entity
+@DiscriminatorValue(CatOther.TYPE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CatOther extends Category {
+
+    public static final String TYPE = "OTHER";
+
+    private CatOther(String name, String categoryCode) {
+        super(name, categoryCode);
+    }
+
+    public static CatOther of(String name, String code) {
+        return new CatOther(name, code);
+    }
+
+    @Override
+    public String getCategoryType() {
+        return TYPE;
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/CatSky.java
+++ b/src/main/java/org/leisureup/location/internal/domain/CatSky.java
@@ -1,0 +1,29 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 하늘 타입 카테고리
+ */
+@Getter
+@Entity
+@DiscriminatorValue(CatSky.TYPE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CatSky extends Category {
+
+    public static final String TYPE = "SKY";
+
+    private CatSky(String name, String categoryCode) {
+        super(name, categoryCode);
+    }
+
+    public static CatSky of(String name, String categoryCode) {
+        return new CatSky(name, categoryCode);
+    }
+
+    @Override
+    public String getCategoryType() {
+        return TYPE;
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/CatWater.java
+++ b/src/main/java/org/leisureup/location/internal/domain/CatWater.java
@@ -1,0 +1,29 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 물 타입 카테고리
+ */
+@Getter
+@Entity
+@DiscriminatorValue(CatWater.TYPE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CatWater extends Category {
+
+    public static final String TYPE = "WATER";
+
+    public CatWater(String name, String categoryCode) {
+        super(name, categoryCode);
+    }
+
+    public static CatWater of(String name, String categoryCode) {
+        return new CatWater(name, categoryCode);
+    }
+
+    @Override
+    public String getCategoryType() {
+        return TYPE;
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/Category.java
+++ b/src/main/java/org/leisureup/location/internal/domain/Category.java
@@ -1,0 +1,48 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.*;
+import java.time.*;
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.jpa.domain.support.*;
+
+/**
+ * 카테고리 타입 분류
+ */
+@Getter
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "category_type")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(length = 50, nullable = false)
+    private String name;
+
+    @NotBlank
+    @Column(length = 20, nullable = false, unique = true)
+    private String categoryCode;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime lastModifiedAt;
+
+    protected Category(String name, String categoryCode) {
+        this.name = name;
+        this.categoryCode = categoryCode;
+    }
+
+    public abstract String getCategoryType();
+}

--- a/src/main/java/org/leisureup/location/internal/domain/GpsCord.java
+++ b/src/main/java/org/leisureup/location/internal/domain/GpsCord.java
@@ -1,0 +1,35 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * GPS 경도 (x), 위도 (y) 좌표
+ */
+@Getter
+@Setter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class GpsCord {
+
+    /**
+     * 경도
+     */
+    @Column(nullable = false)
+    private double gpsX;
+
+    /**
+     * 위도
+     */
+    @Column(nullable = false)
+    private double gpsY;
+
+    public static GpsCord of(double x, double y) {
+        return new GpsCord(x, y);
+    }
+
+    public static GpsCord of(GpsCord cord) {
+        return new GpsCord(cord.getGpsX(), cord.getGpsY());
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/Location.java
+++ b/src/main/java/org/leisureup/location/internal/domain/Location.java
@@ -1,0 +1,68 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * DB 에 저장되는 한 장소
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Location extends LocationTimeStamp {
+
+    @Id
+    private Long id;
+
+    @Embedded
+    private GpsCord gpsCord;
+
+    @Embedded
+    private Address address;
+
+    // 장소 제목 (이름)
+    @Column(length = 200, nullable = false)
+    private String title;
+
+    @Embedded
+    private LocationDescription description;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category locationCategory;
+
+    private Location(
+            long id, String title, GpsCord gpsCord,
+            Address address, LocationDescription locationDescription
+    ) {
+        this.id = id;
+        this.title = title;
+        this.gpsCord = gpsCord;
+        this.address = address;
+        this.description = locationDescription;
+    }
+
+    @Builder
+    public static Location of(
+            long id, String title, GpsCord gpsCord,
+            Address address, LocationDescription description
+    ) {
+        return new Location(id, title, gpsCord, address, description);
+    }
+
+    public void changeCord(GpsCord cord) {
+        this.gpsCord = GpsCord.of(cord);
+    }
+
+    public void changeAddress(Address address) {
+        this.address = Address.of(address);
+    }
+
+    public void changeDescription(LocationDescription description) {
+        this.description = LocationDescription.of(description);
+    }
+
+    public void changeCategory(Category category) {
+        this.locationCategory = category;
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/LocationDescription.java
+++ b/src/main/java/org/leisureup/location/internal/domain/LocationDescription.java
@@ -1,0 +1,67 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 어느 장소에 대한 세부 정보
+ */
+@Getter
+@Setter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class LocationDescription {
+
+    /**
+     * 장소 설명글
+     *
+     * <pre>
+     * {@code
+     * Ex) 동촌유원지는 대구시 동쪽 금호강변에 있는 44만 평의 유원지로 ...
+     * }
+     * </pre>
+     */
+    @Lob
+    private String overview;
+
+    /**
+     * 장소 홈페이지 url
+     *
+     * @warning {@code TourApi} 에서 해당 정보는 {@code <a href="...">} 와 같은 태그로 제공됨. 그래서 파싱 제대로 안하면 이상할수도
+     * 있음.
+     */
+    @Column(length = 100)
+    private String homepageInfo;
+
+    @Column(length = 30)
+    private String telephoneNumber;
+
+    /**
+     * 500 x 300 크기 썸네일 이미지
+     */
+    @Column(length = 150)
+    private String largeThumbnailUrl;
+
+    /**
+     * 150 x 100 크기 썸네일 이미지
+     */
+    @Column(length = 150)
+    private String smallThumbnailUrl;
+
+    public static LocationDescription of(
+            String overview, String homepageInfo, String telephoneNumber,
+            String largeThumbnailUrl, String smallThumbnailUrl
+    ) {
+        return new LocationDescription(
+                overview, homepageInfo, telephoneNumber, largeThumbnailUrl, smallThumbnailUrl
+        );
+    }
+
+    public static LocationDescription of(LocationDescription desc) {
+        return of(
+                desc.getOverview(), desc.getHomepageInfo(), desc.getTelephoneNumber(),
+                desc.getLargeThumbnailUrl(), desc.getSmallThumbnailUrl()
+        );
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/LocationTimeStamp.java
+++ b/src/main/java/org/leisureup/location/internal/domain/LocationTimeStamp.java
@@ -1,0 +1,51 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import java.time.*;
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.jpa.domain.support.*;
+
+/**
+ * 어느 장소에 대한 정보 동기화를 위한 timestamp
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class LocationTimeStamp {
+
+    /**
+     * DB 에 정보가 생성된 시각
+     */
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime storedAt;
+
+    /**
+     * 우리 DB 가 마지막으로 동기화한 시각
+     */
+    @CreatedDate
+    @Column(nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime lastModifiedAt;
+
+    /**
+     * Api 정보가 마지막으로 수정된 시각
+     * <p>
+     * {@code TourApi} 의 {@code modifiedtime}
+     */
+    @Column(nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime lastChangedAt;
+
+    /**
+     * 동기화 되었음을 기록
+     *
+     * @param time {@code TourApi} 의 {@code modifiedtime}
+     */
+    public void synchronizeTo(LocalDateTime time) {
+        this.lastChangedAt = time;
+        this.lastModifiedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/dto/response/GetLocationResponse.java
+++ b/src/main/java/org/leisureup/location/internal/dto/response/GetLocationResponse.java
@@ -1,0 +1,18 @@
+package org.leisureup.location.internal.dto.response;
+
+public record GetLocationResponse(
+        Long id, String name,
+        double gpsX, double gpsY,
+        String briefAddress, String detailedAddress, String zipcode,
+
+        String introduction,
+        String homepageUrl, String telephone,
+        String largeThumbnail, String smallThumbnail,
+
+        Category category
+) {
+
+    public enum Category {
+        EARTH, WATER, SKY, OTHER
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/repository/CategoryRepository.java
+++ b/src/main/java/org/leisureup/location/internal/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package org.leisureup.location.internal.repository;
+
+import org.leisureup.location.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/src/main/java/org/leisureup/location/internal/repository/LocationRepository.java
+++ b/src/main/java/org/leisureup/location/internal/repository/LocationRepository.java
@@ -1,0 +1,8 @@
+package org.leisureup.location.internal.repository;
+
+import org.leisureup.location.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface LocationRepository extends JpaRepository<Location, Long> {
+
+}

--- a/src/main/java/org/leisureup/location/internal/service/LocationFetchService.java
+++ b/src/main/java/org/leisureup/location/internal/service/LocationFetchService.java
@@ -1,0 +1,31 @@
+package org.leisureup.location.internal.service;
+
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.location.internal.dto.response.*;
+import org.leisureup.location.internal.repository.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LocationFetchService {
+
+    private final LocationRepository locationRepo;
+
+    /**
+     * {@code locationId} 에 해당하는 장소를 가져오고 DB 에 저장한다.
+     *
+     * @param locationId 장소 id
+     */
+    @Transactional
+    public GetLocationResponse fetchAndStoreLocation(Long locationId) {
+        // TODO : 완성하기
+        // TourApi 에 해당 장소가 없으면 not found
+        // TourApi 응답을 받지 못하거나 에러가 발생했으면 internal server error
+        // 그 외 성공적으로 가져오면 DB 에 정보 저장 필요
+        throw new NotImplemented();
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/service/LocationService.java
+++ b/src/main/java/org/leisureup/location/internal/service/LocationService.java
@@ -1,0 +1,38 @@
+package org.leisureup.location.internal.service;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.location.internal.domain.*;
+import org.leisureup.location.internal.dto.response.*;
+import org.leisureup.location.internal.repository.*;
+import org.springframework.stereotype.*;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+    private final LocationRepository locationRepo;
+    private final LocationFetchService fetchService;
+
+    /**
+     * 어느 한 장소의 정보를 조회한다.
+     *
+     * @param locationId 장소 id
+     */
+    public GetLocationResponse getLocation(Long locationId) {
+
+        Optional<Location> optional = locationRepo.findById(locationId);
+
+        if (optional.isPresent()) {
+            return buildResponse(optional.get());
+        }
+
+        return fetchService.fetchAndStoreLocation(locationId);
+    }
+
+    private GetLocationResponse buildResponse(Location location) {
+        // TODO: 완성하기
+        throw new NotImplemented();
+    }
+}

--- a/src/main/java/org/leisureup/map/internal/controller/MapController.java
+++ b/src/main/java/org/leisureup/map/internal/controller/MapController.java
@@ -1,9 +1,9 @@
 package org.leisureup.map.internal.controller;
 
-import lombok.RequiredArgsConstructor;
-import org.leisureup.global.response.ApiResponse;
-import org.leisureup.map.internal.dto.KakaoPlaceResponse;
-import org.leisureup.map.internal.service.MapService;
+import lombok.*;
+import org.leisureup.global.response.*;
+import org.leisureup.map.internal.dto.*;
+import org.leisureup.map.internal.service.*;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,6 +17,9 @@ public class MapController {
             @RequestParam double y,
             @RequestParam(defaultValue = "1000") int radius,
             @RequestParam String category) {
-        return ApiResponse.success(mapService.searchCategory(x,y,radius,category));
+        return ApiResponse.success(
+                200,
+                mapService.searchCategory(x, y, radius, category)
+        );
     }
 }

--- a/src/main/java/org/leisureup/travel/internal/travel/service/TravelService.java
+++ b/src/main/java/org/leisureup/travel/internal/travel/service/TravelService.java
@@ -1,11 +1,11 @@
 package org.leisureup.travel.internal.travel.service;
 
-import lombok.RequiredArgsConstructor;
-import org.leisureup.global.response.ApiResponse;
-import org.leisureup.travel.internal.travel.domain.Travel;
-import org.leisureup.travel.internal.travel.dto.CreateTravelDto;
-import org.leisureup.travel.internal.travel.repository.TravelRepository;
-import org.springframework.stereotype.Service;
+import lombok.*;
+import org.leisureup.global.response.*;
+import org.leisureup.travel.internal.travel.domain.*;
+import org.leisureup.travel.internal.travel.dto.*;
+import org.leisureup.travel.internal.travel.repository.*;
+import org.springframework.stereotype.*;
 
 @Service
 @RequiredArgsConstructor
@@ -17,9 +17,9 @@ public class TravelService {
         Travel entity = createTravelDto.toEntity();
         try {
             Travel saved = travelRepository.save(entity);
-            return ApiResponse.success("여행 정보가 저장되었습니다.");
+            return ApiResponse.success(201, "여행 정보가 저장되었습니다.");
         } catch (Exception e) {
-            return ApiResponse.failure("저장 중 오류가 발생했습니다: " + e.getMessage());
+            return ApiResponse.failure(500, "저장 중 오류가 발생했습니다: " + e.getMessage());
         }
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,6 +34,26 @@ spring:
       port: 6379
       password:
 
+springdoc:
+  cache.disabled: true
+  api-docs.groups.enabled: true
+
+  swagger-ui:
+    enabled: true
+    path: /api-doc
+    tags-sorter: alpha
+    operations-sorter: method
+    display-request-duration: true
+
+  api-docs.path: /api-doc
+
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  show-oauth2-endpoints: true
+  show-actuator: true
+  show-login-endpoint: true
+  paths-to-match: /**
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

1. Swagger 를 추가했습니다. `/api-doc` 을 통해 확인 가능합니다.
2. `ApiResponse` 를 통해 HTTP code 를 설정하는 기능을 추가했습니다.
3. `location` 도메인 관련 엔티티를 추가했습니다. `(Location.java, Category.java)`
4. API 명세서에 따라 관련 controller, service 의 뼈대를 구성했습니다. `(아직 구현 X, 테스트 추가 X)`

## 💬 리뷰 요구사항 (선택)

`None`
