### PR TITLE
Feat/member - `member` 도메인 관련 entity, 기본 구조 추가

### DIFF
--- a/src/main/java/org/leisureup/LeisureUp.java
+++ b/src/main/java/org/leisureup/LeisureUp.java
@@ -4,7 +4,9 @@ import org.springframework.boot.*;
 import org.springframework.boot.autoconfigure.*;
 import org.springframework.cloud.openfeign.*;
 import org.springframework.data.jpa.repository.config.*;
+import org.springframework.modulith.*;
 
+@Modulithic
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableFeignClients(basePackages = "org.leisureup")

--- a/src/main/java/org/leisureup/global/exception/BadRequestException.java
+++ b/src/main/java/org/leisureup/global/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package org.leisureup.global.exception;
+
+public class BadRequestException extends CustomException {
+
+    public BadRequestException(String message) {
+        super(400, message);
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -1,8 +1,80 @@
 package org.leisureup.member.internal.controller;
 
+import jakarta.validation.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.global.response.*;
+import org.leisureup.member.internal.dto.request.*;
+import org.leisureup.member.internal.dto.response.*;
+import org.leisureup.member.internal.service.*;
+import org.springframework.data.domain.*;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
 public class MemberController {
 
+    // TODO : Request header 의 jwt 로 member id 가져오는 기능 필요
+
+    private final MemberService memberService;
+
+    private static PageRequest toPageRequest(int page, int size) {
+
+        if (page < 0 || size <= 0) {
+            throw new BadRequestException("Bad request");
+        }
+
+        return PageRequest.of(page, Math.min(size, 100));
+    }
+
+    // 멤버 정보 조회
+    @GetMapping
+    public ApiResponse<GetMemberResponse> getMember() {
+        // TODO : 완성하기
+        throw new NotImplemented("API /member not implemented yet");
+    }
+
+    // 니즈 수집 질문 응답 저장
+    @PostMapping("/interest")
+    public ApiResponse<?> saveInterest(
+            @Valid @RequestBody
+            SaveInterestRequest req
+    ) {
+        // TODO : 완성하기
+        throw new NotImplemented("API /member/interest not implemented yet");
+    }
+
+    // 찜 목록 조회
+    @GetMapping("/picks")
+    public ApiResponse<PageResponse<PickLocation>> getPickLocations(
+            @RequestParam(value = "page", defaultValue = "0")
+            int page,
+            @RequestParam(value = "size", defaultValue = "10")
+            int size
+    ) {
+        PageRequest req = toPageRequest(page, size);
+        // TODO : 완성하기
+        throw new NotImplemented("API /member/picks (GET) not implemented yet");
+    }
+
+    // 장소 찜 저장
+    @PostMapping("/picks")
+    public ApiResponse<?> savePickLocation(
+            @Valid SavePickLocationRequest req
+    ) {
+        // TODO : 완성하기
+        throw new NotImplemented("API /member/picks (POST) not implemented yet");
+    }
+
+    // 찜 장소 삭제
+    @DeleteMapping("/picks/{locationId}")
+    public ApiResponse<?> deletePickLocation(
+            @Valid @Positive @NotNull
+            @PathVariable Long locationId
+    ) {
+        // TODO : 완성하기
+        throw new NotImplemented("API /member/pick/{locationId} not implemented yet");
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/AppleOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/AppleOAuth.java
@@ -1,0 +1,20 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Apple 소셜 인증 정보를 저장할 엔티티
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppleOAuth extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private Member member;
+}

--- a/src/main/java/org/leisureup/member/internal/domain/BaseTimeEntity.java
+++ b/src/main/java/org/leisureup/member/internal/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import java.time.*;
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.jpa.domain.support.*;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime lastModifiedAt;
+}

--- a/src/main/java/org/leisureup/member/internal/domain/GoogleOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/GoogleOAuth.java
@@ -1,0 +1,21 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Google 소셜 인증 정보를 저장할 엔티티
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoogleOAuth extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private Member member;
+
+}

--- a/src/main/java/org/leisureup/member/internal/domain/Interest.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Interest.java
@@ -1,0 +1,26 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자 니즈 수집 질문을 저장하는 엔티티
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Interest {
+
+    @Id
+    private Long memberId;
+
+    @MapsId
+    @OneToOne(optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Setter
+    @Embedded
+    private InterestInfo info;
+
+}

--- a/src/main/java/org/leisureup/member/internal/domain/Interest.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Interest.java
@@ -23,4 +23,10 @@ public class Interest {
     @Embedded
     private InterestInfo info;
 
+    public static Interest of(Member member, InterestInfo info) {
+        Interest interest = new Interest();
+        interest.member = member;
+        interest.info = InterestInfo.of(info);
+        return interest;
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/InterestInfo.java
+++ b/src/main/java/org/leisureup/member/internal/domain/InterestInfo.java
@@ -1,0 +1,58 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자 니즈 수집 응답 세부사항
+ */
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterestInfo {
+
+    private int ageRange;
+
+    @Enumerated(EnumType.STRING)
+    private With with;
+
+    @Enumerated(EnumType.STRING)
+    private Experience experience;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    @Enumerated(EnumType.STRING)
+    private LeisureType leisureType;
+
+    @Enumerated(EnumType.STRING)
+    private PreferredSeason preferredSeason;
+
+    @Enumerated(EnumType.STRING)
+    private Difficulty difficulty;
+
+    public enum With {
+        alone, friend, family
+    }
+
+    public enum Experience {
+        first, couple, several
+    }
+
+    public enum Type {
+        relieving, thrilling
+    }
+
+    public enum LeisureType {
+        water, earth, sky, any
+    }
+
+    public enum PreferredSeason {
+        spring, summer, autumn, winter, any
+    }
+
+    public enum Difficulty {
+        low, medium, high
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/domain/InterestInfo.java
+++ b/src/main/java/org/leisureup/member/internal/domain/InterestInfo.java
@@ -2,6 +2,10 @@ package org.leisureup.member.internal.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.leisureup.member.internal.domain.InterestInfo.*;
+import org.leisureup.member.internal.domain.InterestInfo.With;
+import org.leisureup.member.internal.dto.request.*;
+import org.leisureup.member.internal.dto.request.SaveInterestRequest.*;
 
 /**
  * 사용자 니즈 수집 응답 세부사항
@@ -32,6 +36,34 @@ public class InterestInfo {
     @Enumerated(EnumType.STRING)
     private Difficulty difficulty;
 
+    public static InterestInfo of(SaveInterestRequest request) {
+        int age = request.ageRange();
+        var reqWith = request.with();
+        var reqExp = request.experience();
+        var reqType = request.type();
+        var reqLeisureType = request.leisureType();
+        var reqSeason = request.preferredSeason();
+        var reqDifficulty = request.difficulty();
+
+        return new InterestInfo(
+                age,
+                Util.with(reqWith), Util.experience(reqExp),
+                Util.type(reqType), Util.leisureType(reqLeisureType),
+                Util.preferredSeason(reqSeason), Util.difficulty(reqDifficulty)
+        );
+    }
+
+    public static InterestInfo of(InterestInfo given) {
+        InterestInfo info = new InterestInfo();
+        info.with = given.with;
+        info.experience = given.experience;
+        info.leisureType = given.leisureType;
+        info.preferredSeason = given.preferredSeason;
+        info.difficulty = given.difficulty;
+        info.type = given.type;
+        return info;
+    }
+
     public enum With {
         alone, friend, family
     }
@@ -54,5 +86,58 @@ public class InterestInfo {
 
     public enum Difficulty {
         low, medium, high
+    }
+}
+
+class Util {
+
+    static With with(ReqWith reqWith) {
+        return switch (reqWith) {
+            case alone -> With.alone;
+            case friend -> With.friend;
+            case family -> With.family;
+        };
+    }
+
+    static Experience experience(ReqExperience reqExp) {
+        return switch (reqExp) {
+            case first -> Experience.first;
+            case couple -> Experience.couple;
+            case several -> Experience.several;
+        };
+    }
+
+    static Type type(ReqType reqType) {
+        return switch (reqType) {
+            case relieving -> Type.relieving;
+            case thrilling -> Type.thrilling;
+        };
+    }
+
+    static LeisureType leisureType(ReqLeisureType reqLeisureType) {
+        return switch (reqLeisureType) {
+            case water -> LeisureType.water;
+            case earth -> LeisureType.earth;
+            case sky -> LeisureType.sky;
+            case any -> LeisureType.any;
+        };
+    }
+
+    static PreferredSeason preferredSeason(ReqPreferredSeason reqSeason) {
+        return switch (reqSeason) {
+            case spring -> PreferredSeason.spring;
+            case summer -> PreferredSeason.summer;
+            case autumn -> PreferredSeason.autumn;
+            case winter -> PreferredSeason.winter;
+            case any -> PreferredSeason.any;
+        };
+    }
+
+    static Difficulty difficulty(ReqDifficulty reqDifficulty) {
+        return switch (reqDifficulty) {
+            case low -> Difficulty.low;
+            case medium -> Difficulty.medium;
+            case high -> Difficulty.high;
+        };
     }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/KakaoOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/KakaoOAuth.java
@@ -1,0 +1,21 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Kakao 소셜 인증 정보를 저장할 엔티티
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoOAuth extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private Member member;
+
+}

--- a/src/main/java/org/leisureup/member/internal/domain/Member.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Member.java
@@ -1,0 +1,26 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickname;
+    private String email;
+
+    private Member(String nickname, String email) {
+        this.nickname = nickname;
+        this.email = email;
+    }
+
+    public static Member of(String nickname, String email) {
+        return new Member(nickname, email);
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/domain/Pick.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Pick.java
@@ -1,0 +1,23 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자 찜 목록을 저장할 엔티티
+ */
+@Getter
+@Entity
+@IdClass(PickCompositeKey.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Pick extends BaseTimeEntity {
+
+    @Id
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "a_member_id", nullable = false, updatable = false)
+    private Member member;
+
+    @Id
+    @Column(name = "b_location_id", nullable = false, updatable = false)
+    private long locationId;
+}

--- a/src/main/java/org/leisureup/member/internal/domain/PickCompositeKey.java
+++ b/src/main/java/org/leisureup/member/internal/domain/PickCompositeKey.java
@@ -1,0 +1,15 @@
+package org.leisureup.member.internal.domain;
+
+import lombok.*;
+
+/**
+ * 사용자 찜 목록 저장용 복합키
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class PickCompositeKey {
+
+    private Member member;
+    private long locationId;
+}

--- a/src/main/java/org/leisureup/member/internal/dto/request/SaveInterestRequest.java
+++ b/src/main/java/org/leisureup/member/internal/dto/request/SaveInterestRequest.java
@@ -1,0 +1,39 @@
+package org.leisureup.member.internal.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record SaveInterestRequest(
+        @Positive int ageRange,
+
+        @NotNull ReqWith with,
+        @NotNull ReqExperience experience,
+        @NotNull ReqType type,
+        @NotNull ReqLeisureType leisureType,
+        @NotNull ReqPreferredSeason preferredSeason,
+        @NotNull ReqDifficulty difficulty
+) {
+
+    public enum ReqWith {
+        alone, friend, family
+    }
+
+    public enum ReqExperience {
+        first, couple, several
+    }
+
+    public enum ReqType {
+        relieving, thrilling
+    }
+
+    public enum ReqLeisureType {
+        water, earth, sky, any
+    }
+
+    public enum ReqPreferredSeason {
+        spring, summer, autumn, winter, any
+    }
+
+    public enum ReqDifficulty {
+        low, medium, high
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/dto/request/SavePickLocationRequest.java
+++ b/src/main/java/org/leisureup/member/internal/dto/request/SavePickLocationRequest.java
@@ -1,0 +1,10 @@
+package org.leisureup.member.internal.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record SavePickLocationRequest(
+        @NotNull @Positive
+        Long locationId
+) {
+
+}

--- a/src/main/java/org/leisureup/member/internal/dto/response/GetMemberResponse.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/GetMemberResponse.java
@@ -1,0 +1,15 @@
+package org.leisureup.member.internal.dto.response;
+
+import org.leisureup.member.internal.domain.*;
+
+public record GetMemberResponse(
+        String nickname,
+        String email
+) {
+
+    public static GetMemberResponse of(Member member) {
+        return new GetMemberResponse(
+                member.getNickname(), member.getEmail()
+        );
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/dto/response/PageResponse.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/PageResponse.java
@@ -1,0 +1,13 @@
+package org.leisureup.member.internal.dto.response;
+
+import java.util.*;
+
+public record PageResponse<T>(
+        long totalPages,
+        int pageNo,
+        int pageSize,
+        boolean lastPage,
+        List<T> elements
+) {
+
+}

--- a/src/main/java/org/leisureup/member/internal/dto/response/PickLocation.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/PickLocation.java
@@ -1,0 +1,14 @@
+package org.leisureup.member.internal.dto.response;
+
+public record PickLocation(
+        Long id,
+        String name,
+        String largeThumbnail,
+        String smallThumbnail,
+        Category category
+) {
+
+    public enum Category {
+        EARTH, WATER, SKY, OTHER
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
@@ -1,0 +1,16 @@
+package org.leisureup.member.internal.repository;
+
+import java.util.*;
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface AppleOAuthRepository
+        extends JpaRepository<AppleOAuth, Long> {
+
+    @Query("""
+            select mid from AppleOAuth ao
+            right join ao.member.id mid
+            where ao.id = :socialId
+            """)
+    Optional<Long> findMemberIdBySocial(Long socialId);
+}

--- a/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
@@ -1,0 +1,16 @@
+package org.leisureup.member.internal.repository;
+
+import java.util.*;
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface GoogleOAuthRepository
+        extends JpaRepository<GoogleOAuth, Long> {
+
+    @Query("""
+            select mid from GoogleOAuth go
+            right join go.member.id mid
+            where go.id = :socialId
+            """)
+    Optional<Long> findMemberIdBySocial(Long socialId);
+}

--- a/src/main/java/org/leisureup/member/internal/repository/InterestRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/InterestRepository.java
@@ -1,0 +1,8 @@
+package org.leisureup.member.internal.repository;
+
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface InterestRepository extends JpaRepository<Interest, Long> {
+
+}

--- a/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
@@ -1,0 +1,16 @@
+package org.leisureup.member.internal.repository;
+
+import java.util.*;
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface KakaoOAuthRepository
+        extends JpaRepository<KakaoOAuth, Long> {
+
+    @Query("""
+            select mid from KakaoOAuth ko
+            right join ko.member.id mid
+            where ko.id = :socialId
+            """)
+    Optional<Long> findMemberIdBySocial(Long socialId);
+}

--- a/src/main/java/org/leisureup/member/internal/repository/MemberRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package org.leisureup.member.internal.repository;
+
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/org/leisureup/member/internal/service/MemberService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberService.java
@@ -1,0 +1,49 @@
+package org.leisureup.member.internal.service;
+
+import jakarta.transaction.*;
+import java.util.*;
+import lombok.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.member.internal.domain.*;
+import org.leisureup.member.internal.dto.request.*;
+import org.leisureup.member.internal.dto.response.*;
+import org.leisureup.member.internal.repository.*;
+import org.springframework.stereotype.*;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepo;
+    private final InterestRepository interestRepo;
+
+    public GetMemberResponse getMember(Long memberId) {
+        Member find = memberRepo.findById(memberId)
+                .orElseThrow(() -> new NotFound("Member not found"));
+
+        return GetMemberResponse.of(find);
+    }
+
+    /**
+     * 사용자 니즈 수집 질문을 저장한다.
+     * <p>
+     * 이전에 응답했으면 수정해 저장한다.
+     */
+    @Transactional
+    public void saveInterest(Long memberId, SaveInterestRequest req) {
+        Member member = memberRepo.findById(memberId)
+                .orElseThrow(() -> new NotFound("Member not found"));
+
+        InterestInfo savingInfo = InterestInfo.of(req);
+        Optional<Interest> optional = interestRepo.findById(memberId);
+
+        if (optional.isPresent()) {
+            Interest interest = optional.get();
+            interest.setInfo(savingInfo);
+            return;
+        }
+
+        interestRepo.save(Interest.of(member, savingInfo));
+    }
+
+}

--- a/src/main/java/org/leisureup/member/spi/MemberSpi.java
+++ b/src/main/java/org/leisureup/member/spi/MemberSpi.java
@@ -1,0 +1,12 @@
+package org.leisureup.member.spi;
+
+import java.util.*;
+
+public interface MemberSpi {
+
+    boolean notExists(Long memberId);
+
+    Optional<Long> getMemberIdWithSocial(
+            SocialType type, Long socialId
+    );
+}

--- a/src/main/java/org/leisureup/member/spi/SocialType.java
+++ b/src/main/java/org/leisureup/member/spi/SocialType.java
@@ -1,0 +1,5 @@
+package org.leisureup.member.spi;
+
+public enum SocialType {
+    APPLE, GOOGLE, KAKAO
+}

--- a/src/main/java/org/leisureup/member/spi/internal/AppleSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/AppleSocialAuth.java
@@ -1,0 +1,24 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Component
+@RequiredArgsConstructor
+public class AppleSocialAuth implements SocialAuth {
+
+    private final AppleOAuthRepository repository;
+
+    @Override
+    public Optional<Long> findMemberIdBySocial(Long socialId) {
+        return repository.findMemberIdBySocial(socialId);
+    }
+
+    @Override
+    public SocialType getSocialAuthType() {
+        return SocialType.APPLE;
+    }
+}

--- a/src/main/java/org/leisureup/member/spi/internal/GoogleSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/GoogleSocialAuth.java
@@ -1,0 +1,24 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleSocialAuth implements SocialAuth {
+
+    private final GoogleOAuthRepository repository;
+
+    @Override
+    public Optional<Long> findMemberIdBySocial(Long socialId) {
+        return repository.findMemberIdBySocial(socialId);
+    }
+
+    @Override
+    public SocialType getSocialAuthType() {
+        return SocialType.GOOGLE;
+    }
+}

--- a/src/main/java/org/leisureup/member/spi/internal/KakaoSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/KakaoSocialAuth.java
@@ -1,0 +1,24 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoSocialAuth implements SocialAuth {
+
+    private final KakaoOAuthRepository repository;
+
+    @Override
+    public Optional<Long> findMemberIdBySocial(Long socialId) {
+        return repository.findMemberIdBySocial(socialId);
+    }
+
+    @Override
+    public SocialType getSocialAuthType() {
+        return SocialType.KAKAO;
+    }
+}

--- a/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
+++ b/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
@@ -1,0 +1,35 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Component
+public class MemberSpiImpl implements MemberSpi {
+
+    private final MemberRepository memberRepo;
+    private final Map<SocialType, SocialAuth> socialAuths;
+
+    public MemberSpiImpl(
+            MemberRepository memberRepo,
+            List<SocialAuth> socialAuths
+    ) {
+        this.memberRepo = memberRepo;
+        this.socialAuths = socialAuths.stream().collect(
+                Collectors.toMap(SocialAuth::getSocialAuthType, Function.identity())
+        );
+    }
+
+    @Override
+    public boolean notExists(Long memberId) {
+        return !memberRepo.existsById(memberId);
+    }
+
+    @Override
+    public Optional<Long> getMemberIdWithSocial(SocialType type, Long socialId) {
+        return socialAuths.get(type).findMemberIdBySocial(socialId);
+    }
+}

--- a/src/main/java/org/leisureup/member/spi/internal/SocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/SocialAuth.java
@@ -1,0 +1,11 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import org.leisureup.member.spi.*;
+
+public interface SocialAuth {
+
+    Optional<Long> findMemberIdBySocial(Long socialId);
+
+    SocialType getSocialAuthType();
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,7 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+        globally_quoted_identifiers: true
 
   data:
     redis:

--- a/src/test/java/org/leisureup/IntegrationTestSupport.java
+++ b/src/test/java/org/leisureup/IntegrationTestSupport.java
@@ -1,0 +1,8 @@
+package org.leisureup;
+
+import org.springframework.boot.test.context.*;
+
+@SpringBootTest
+public abstract class IntegrationTestSupport {
+
+}

--- a/src/test/java/org/leisureup/LeisureUpTests.java
+++ b/src/test/java/org/leisureup/LeisureUpTests.java
@@ -4,17 +4,30 @@ import lombok.extern.slf4j.*;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.*;
 import org.springframework.modulith.core.*;
+import org.springframework.modulith.docs.*;
 
 @Slf4j
 @SpringBootTest
 class LeisureUpTests {
 
+    private final ApplicationModules modules
+            = ApplicationModules.of(LeisureUp.class);
+
     @Test
     void contextLoads() {
-        ApplicationModules applicationModules = ApplicationModules.of(LeisureUp.class);
 
-        applicationModules.forEach(m -> log.info("Module: {}", m));
-        applicationModules.verify();
     }
 
+    @Test
+    void verifyModules() {
+        modules.forEach(m -> log.info("Module : {}", m));
+        modules.verify();
+    }
+
+    @Test
+    void writeDocument() {
+        new Documenter(modules)
+                .writeModulesAsPlantUml()
+                .writeIndividualModulesAsPlantUml();
+    }
 }

--- a/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
+++ b/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
@@ -1,0 +1,73 @@
+package org.leisureup.member.internal.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.extern.slf4j.*;
+import org.junit.jupiter.api.*;
+import org.leisureup.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.member.internal.domain.*;
+import org.leisureup.member.internal.dto.request.*;
+import org.leisureup.member.internal.dto.request.SaveInterestRequest.*;
+import org.leisureup.member.internal.repository.*;
+import org.springframework.beans.factory.annotation.*;
+
+@Slf4j
+class MemberServiceTest extends IntegrationTestSupport {
+
+    private static final Long invalidMemberId = Long.MAX_VALUE;
+    private static Long testMemberId;
+    @Autowired
+    MemberService service;
+    @Autowired
+    MemberRepository memberRepo;
+    @Autowired
+    InterestRepository interestRepo;
+
+    private static SaveInterestRequest genReq(int ageRange) {
+        return new SaveInterestRequest(
+                ageRange, ReqWith.alone, ReqExperience.first,
+                ReqType.relieving, ReqLeisureType.any, ReqPreferredSeason.any,
+                ReqDifficulty.low
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        testMemberId = memberRepo.save(
+                Member.of("test", "test")
+        ).getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        interestRepo.deleteAll();
+        memberRepo.deleteAll();
+    }
+
+    @Test
+    @DisplayName("니즈 수집 질문을 저장한다.")
+    void saveInterest() {
+
+        var req = genReq(10);
+
+        service.saveInterest(testMemberId, req);
+
+        // 정보가 정상적으로 저장된다.
+        assertThat(interestRepo.findById(testMemberId))
+                .isPresent().get()
+                .hasNoNullFieldsOrProperties();
+    }
+
+    @Test
+    @DisplayName("멤버가 존재하지 않으면 에러가 발생한다.")
+    void memberNotFound() {
+
+        var req = genReq(20);
+
+        assertThatThrownBy(() -> service.getMember(invalidMemberId))
+                .isInstanceOf(NotFound.class);
+        assertThatThrownBy(() -> service.saveInterest(invalidMemberId, req))
+                .isInstanceOf(NotFound.class);
+    }
+}

--- a/src/test/java/org/leisureup/member/spi/MemberSpiTest.java
+++ b/src/test/java/org/leisureup/member/spi/MemberSpiTest.java
@@ -1,0 +1,96 @@
+package org.leisureup.member.spi;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.stream.*;
+import lombok.extern.slf4j.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.leisureup.*;
+import org.leisureup.member.internal.repository.*;
+import org.mockito.invocation.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.test.context.bean.override.mockito.*;
+
+@Slf4j
+class MemberSpiTest extends IntegrationTestSupport {
+
+    private static final Long memberId = 1L;
+    private static final Long validKakaoId = 1L,
+            validGoogleId = 2L,
+            validAppleId = 3L;
+    private static final Long invalidKakaoId = 4L,
+            invalidGoogleId = 5L,
+            invalidAppleId = 6L;
+    @Autowired
+    MemberSpi memberSpi;
+    @MockitoBean
+    AppleOAuthRepository appleOAuthRepo;
+    @MockitoBean
+    GoogleOAuthRepository googleOAuthRepo;
+    @MockitoBean
+    KakaoOAuthRepository kakaoOAuthRepo;
+
+    private static Stream<Arguments> validSocialArgs() {
+        return Stream.of(
+                Arguments.of(SocialType.KAKAO, validKakaoId),
+                Arguments.of(SocialType.GOOGLE, validGoogleId),
+                Arguments.of(SocialType.APPLE, validAppleId)
+        );
+    }
+
+    private static Stream<Arguments> invalidSocialArgs() {
+        return Stream.of(
+                Arguments.of(SocialType.KAKAO, invalidKakaoId),
+                Arguments.of(SocialType.GOOGLE, invalidGoogleId),
+                Arguments.of(SocialType.APPLE, invalidAppleId)
+        );
+    }
+
+    private static Optional<Long> setupMockAnswer(
+            Long validId, InvocationOnMock invocation
+    ) {
+        Long id = invocation.getArgument(0, Long.class);
+        Long result = validId.equals(id) ? memberId : null;
+        return Optional.ofNullable(result);
+    }
+
+    @BeforeEach
+    void setUp() {
+        when(kakaoOAuthRepo.findMemberIdBySocial(anyLong()))
+                .thenAnswer(invocation ->
+                        setupMockAnswer(validKakaoId, invocation));
+
+        when(googleOAuthRepo.findMemberIdBySocial(anyLong()))
+                .thenAnswer(invocation ->
+                        setupMockAnswer(validGoogleId, invocation));
+
+        when(appleOAuthRepo.findMemberIdBySocial(anyLong()))
+                .thenAnswer(invocation ->
+                        setupMockAnswer(validAppleId, invocation));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validSocialArgs")
+    @DisplayName("등록된 유저는 소셜인증 타입과 번호에 따라 번호를 식별할 수 있다.")
+    void getMemberId(SocialType type, Long socialId) {
+
+        Optional<Long> id = memberSpi.getMemberIdWithSocial(type, socialId);
+
+        assertThat(id).isNotEmpty().get()
+                .isEqualTo(memberId);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidSocialArgs")
+    @DisplayName("등록되지 않은 유저는 번호를 식별할 수 없다.")
+    void cannotGetMemberId(SocialType type, Long socialId) {
+
+        Optional<Long> id = memberSpi.getMemberIdWithSocial(type, socialId);
+
+        assertThat(id).isEmpty();
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,6 +15,7 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+        globally_quoted_identifiers: true
 
   data:
     redis:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

JWT, 소셜 로그인 기능을 진행하기 앞서 `member` 엔티티 구성의 필요성을 느껴 
기초적인 작업을 진행했습니다.

1. `member` 도메인 관련 엔티티를 구성했습니다. `(Member.java, Pick.java, GoogleOAuth 등)`
2. `MemberService`, `MemberController` 의 기초적인 뼈대를 구성했습니다.
3. 타 모듈에 서비스를 제공하는 `MemberSpi` 를 구성했습니다.


## 💬 리뷰 요구사항 (선택)

JWT, 소셜 로그인 기능 전 기초를 위한 작업들이라 가볍게 보시면 좋을 것 같습니다.
