### PR TITLE
Feat/auth - OAuth, Jwt 기반 인증 서비스 일부 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,13 @@ dependencies {
     implementation 'org.springframework.modulith:spring-modulith-starter-jpa'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/org/leisureup/LeisureUp.java
+++ b/src/main/java/org/leisureup/LeisureUp.java
@@ -3,11 +3,13 @@ package org.leisureup;
 import org.springframework.boot.*;
 import org.springframework.boot.autoconfigure.*;
 import org.springframework.cloud.openfeign.*;
+import org.springframework.context.annotation.*;
 import org.springframework.data.jpa.repository.config.*;
 import org.springframework.modulith.*;
 
 @Modulithic
 @EnableJpaAuditing
+@EnableAspectJAutoProxy
 @SpringBootApplication
 @EnableFeignClients(basePackages = "org.leisureup")
 public class LeisureUp {

--- a/src/main/java/org/leisureup/LeisureUp.java
+++ b/src/main/java/org/leisureup/LeisureUp.java
@@ -4,7 +4,9 @@ import org.springframework.boot.*;
 import org.springframework.boot.autoconfigure.*;
 import org.springframework.cloud.openfeign.*;
 import org.springframework.data.jpa.repository.config.*;
+import org.springframework.modulith.*;
 
+@Modulithic
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableFeignClients(basePackages = "org.leisureup")

--- a/src/main/java/org/leisureup/global/AuthHolder.java
+++ b/src/main/java/org/leisureup/global/AuthHolder.java
@@ -1,0 +1,56 @@
+package org.leisureup.global;
+
+import lombok.*;
+import org.springframework.beans.factory.*;
+import org.springframework.stereotype.*;
+import org.springframework.web.context.annotation.*;
+
+@Component
+@RequiredArgsConstructor
+public class AuthHolder {
+
+    private final ObjectProvider<InternalAuth> authProvider;
+
+    /**
+     * 인증된 사용자 ID 를 제공한다.
+     *
+     * @warning Jwt 를 통해 인증이 실패한 경우 반환값이 {@code null} 임에 유의.
+     */
+    public Long getMemberId() {
+        return authProvider.getObject().getId();
+    }
+
+    /**
+     * 인증된 사용자 ID 를 저장한다.
+     */
+    public void setMemberId(Long memberId) {
+        if (memberId == null) {
+            throw new IllegalArgumentException("Member id cannot be null");
+        }
+
+        Long result = authProvider.getObject()
+                .setId(memberId);
+
+        if (!memberId.equals(result)) {
+            throw new IllegalArgumentException(
+                    "Authentication has already been set"
+            );
+        }
+    }
+}
+
+@Component
+@RequestScope
+class InternalAuth {
+
+    private Long memberId;
+
+    public Long setId(Long id) {
+        return memberId != null ?
+                memberId : (memberId = id);
+    }
+
+    public Long getId() {
+        return memberId;
+    }
+}

--- a/src/main/java/org/leisureup/global/JwtAuthIfPossible.java
+++ b/src/main/java/org/leisureup/global/JwtAuthIfPossible.java
@@ -1,0 +1,14 @@
+package org.leisureup.global;
+
+import java.lang.annotation.*;
+
+/**
+ * Jwt 를 통한 인증이 선택적인 유형.
+ * <p>
+ * 토큰이 유효하지 않아도 에러를 일으키지 않음.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JwtAuthIfPossible {
+
+}

--- a/src/main/java/org/leisureup/global/JwtAuthRequired.java
+++ b/src/main/java/org/leisureup/global/JwtAuthRequired.java
@@ -1,0 +1,14 @@
+package org.leisureup.global;
+
+import java.lang.annotation.*;
+
+/**
+ * Jwt 를 통한 인증이 필수적인 유형.
+ * <p>
+ * 토큰이 유효하지 않으면 반드시 에러를 일으킴.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JwtAuthRequired {
+
+}

--- a/src/main/java/org/leisureup/global/auth/aspect/JwtAuthAspect.java
+++ b/src/main/java/org/leisureup/global/auth/aspect/JwtAuthAspect.java
@@ -1,0 +1,72 @@
+package org.leisureup.global.auth.aspect;
+
+import jakarta.servlet.http.*;
+import lombok.*;
+import org.aspectj.lang.annotation.*;
+import org.leisureup.global.*;
+import org.leisureup.global.auth.token.service.*;
+import org.springframework.beans.factory.*;
+import org.springframework.http.*;
+import org.springframework.stereotype.*;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class JwtAuthAspect {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String AUTHORIZATION_HEADER
+            = HttpHeaders.AUTHORIZATION;
+    private final ObjectProvider<HttpServletRequest> requestProvider;
+    private final TokenAuthService tokenAuthService;
+    private final AuthHolder authHolder;
+
+    private static String removeBearerPrefix(String authHeaderVal) {
+
+        return authHeaderVal == null || authHeaderVal.isEmpty() ? "" :
+                authHeaderVal.replace(BEARER_PREFIX, "");
+    }
+
+    // 반드시 Jwt 가 필요한 곳의 PointCut
+    @Pointcut("""
+            @within(org.leisureup.global.JwtAuthRequired) ||
+            @annotation(org.leisureup.global.JwtAuthRequired)
+            """)
+    public void authRequired() {
+    }
+
+    // 선택적으로 Jwt 가 필요한 곳의 PointCut
+    @Pointcut("""
+            @within(org.leisureup.global.JwtAuthIfPossible) ||
+            @annotation(org.leisureup.global.JwtAuthIfPossible)
+            """)
+    public void authIfPossible() {
+    }
+
+    @Before("authRequired()")
+    public void checkJwtAuth() {
+
+        String headerVal = requestProvider.getObject()
+                .getHeader(AUTHORIZATION_HEADER);
+
+        // 헤더가 존재하지 않는다.
+        if (headerVal == null) {
+            throw new UnauthenticatedException();
+        }
+
+        // 토큰이 유효하지 않으면 .getMemberIdFromAt 에서 에러가 발생한다.
+        String accessToken = removeBearerPrefix(headerVal);
+        Long memberId = tokenAuthService.getMemberIdFromAt(accessToken);
+
+        authHolder.setMemberId(memberId);
+    }
+
+    @Before("authIfPossible()")
+    public void checkJwtAuthIfPossible() {
+        try {
+            checkJwtAuth();
+        } catch (Exception ignored) {
+            // 선택적 인가 상황으로 에러는 무시된다
+        }
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/aspect/UnauthenticatedException.java
+++ b/src/main/java/org/leisureup/global/auth/aspect/UnauthenticatedException.java
@@ -1,0 +1,10 @@
+package org.leisureup.global.auth.aspect;
+
+import org.leisureup.global.exception.*;
+
+public class UnauthenticatedException extends CustomException {
+
+    public UnauthenticatedException() {
+        super(401, "Unauthenticated");
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/controller/AuthController.java
+++ b/src/main/java/org/leisureup/global/auth/controller/AuthController.java
@@ -1,0 +1,50 @@
+package org.leisureup.global.auth.controller;
+
+import jakarta.validation.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.leisureup.global.auth.dto.*;
+import org.leisureup.global.auth.dto.request.*;
+import org.leisureup.global.auth.dto.response.*;
+import org.leisureup.global.auth.social.*;
+import org.leisureup.global.auth.token.service.*;
+import org.leisureup.global.response.*;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final SocialAuthService socialAuthService;
+    private final TokenAuthService tokenAuthService;
+
+    // 소셜 로그인 or 회원가입
+    @PostMapping
+    public ApiResponse<SignInUpResponse> loginSingUp(
+            @Valid @RequestBody SignInUpRequest req
+    ) {
+        var resp = socialAuthService.signInOrSignUp(req);
+        boolean created = resp.id() != null;
+        return ApiResponse.success(
+                created ? 201 : 200,
+                resp
+        );
+    }
+
+    // 토큰 재발급
+    @PostMapping("/token")
+    public ApiResponse<RecreateTokenResponse> recreateToken(
+            @Valid @RequestBody RecreateTokenRequest req
+    ) {
+        String rt = req.refreshToken();
+        Long memberId = tokenAuthService.getMemberIdFromRt(rt);
+        Tokens tokens = tokenAuthService.createTokens(memberId);
+
+        return ApiResponse.success(
+                200, RecreateTokenResponse.of(tokens)
+        );
+    }
+
+}

--- a/src/main/java/org/leisureup/global/auth/dto/Tokens.java
+++ b/src/main/java/org/leisureup/global/auth/dto/Tokens.java
@@ -1,0 +1,11 @@
+package org.leisureup.global.auth.dto;
+
+public record Tokens(
+        String accessToken,
+        String refreshToken
+) {
+
+    public static Tokens of(String accessToken, String refreshToken) {
+        return new Tokens(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/dto/request/RecreateTokenRequest.java
+++ b/src/main/java/org/leisureup/global/auth/dto/request/RecreateTokenRequest.java
@@ -1,0 +1,9 @@
+package org.leisureup.global.auth.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record RecreateTokenRequest(
+        @NotBlank String refreshToken
+) {
+
+}

--- a/src/main/java/org/leisureup/global/auth/dto/request/SignInUpRequest.java
+++ b/src/main/java/org/leisureup/global/auth/dto/request/SignInUpRequest.java
@@ -1,0 +1,13 @@
+package org.leisureup.global.auth.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record SignInUpRequest(
+        @NotNull AuthType authType,
+        @NotNull String token
+) {
+
+    public enum AuthType {
+        APPLE, GOOGLE, KAKAO
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/dto/response/RecreateTokenResponse.java
+++ b/src/main/java/org/leisureup/global/auth/dto/response/RecreateTokenResponse.java
@@ -1,0 +1,17 @@
+package org.leisureup.global.auth.dto.response;
+
+import org.leisureup.global.auth.dto.*;
+
+public record RecreateTokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+
+
+    public static RecreateTokenResponse of(Tokens tokens) {
+        return new RecreateTokenResponse(
+                tokens.accessToken(),
+                tokens.refreshToken()
+        );
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/dto/response/SignInUpResponse.java
+++ b/src/main/java/org/leisureup/global/auth/dto/response/SignInUpResponse.java
@@ -1,0 +1,15 @@
+package org.leisureup.global.auth.dto.response;
+
+public record SignInUpResponse(
+        Long id,
+        String accessToken,
+        String refreshToken
+) {
+
+
+    public static SignInUpResponse of(
+            Long id, String accessToken, String refreshToken
+    ) {
+        return new SignInUpResponse(id, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/package-info.java
+++ b/src/main/java/org/leisureup/global/auth/package-info.java
@@ -1,0 +1,4 @@
+@ApplicationModule(displayName = "global::auth")
+package org.leisureup.global.auth;
+
+import org.springframework.modulith.*;

--- a/src/main/java/org/leisureup/global/auth/social/AppleOAuthClient.java
+++ b/src/main/java/org/leisureup/global/auth/social/AppleOAuthClient.java
@@ -1,0 +1,19 @@
+package org.leisureup.global.auth.social;
+
+import org.leisureup.global.auth.dto.request.SignInUpRequest.*;
+import org.springframework.stereotype.*;
+
+@Component
+public class AppleOAuthClient implements OAuthClient {
+
+    @Override
+    public OAuthResponse fetchInfo(String token) {
+        // TODO : Apple OAuth 구현
+        return null;
+    }
+
+    @Override
+    public AuthType getType() {
+        return AuthType.APPLE;
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/social/GoogleOAuthClient.java
+++ b/src/main/java/org/leisureup/global/auth/social/GoogleOAuthClient.java
@@ -1,0 +1,19 @@
+package org.leisureup.global.auth.social;
+
+import org.leisureup.global.auth.dto.request.SignInUpRequest.*;
+import org.springframework.stereotype.*;
+
+@Component
+public class GoogleOAuthClient implements OAuthClient {
+
+    @Override
+    public OAuthResponse fetchInfo(String token) {
+        // TODO : Google OAuth 구현
+        return null;
+    }
+
+    @Override
+    public AuthType getType() {
+        return AuthType.GOOGLE;
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/social/KakaoOAuthClient.java
+++ b/src/main/java/org/leisureup/global/auth/social/KakaoOAuthClient.java
@@ -1,0 +1,19 @@
+package org.leisureup.global.auth.social;
+
+import org.leisureup.global.auth.dto.request.SignInUpRequest.*;
+import org.springframework.stereotype.*;
+
+@Component
+public class KakaoOAuthClient implements OAuthClient {
+
+    @Override
+    public OAuthResponse fetchInfo(String token) {
+        // TODO : Kakao OAuth 구현
+        return null;
+    }
+
+    @Override
+    public AuthType getType() {
+        return AuthType.KAKAO;
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/social/OAuthClient.java
+++ b/src/main/java/org/leisureup/global/auth/social/OAuthClient.java
@@ -1,0 +1,13 @@
+package org.leisureup.global.auth.social;
+
+import org.leisureup.global.auth.dto.request.SignInUpRequest.*;
+
+public interface OAuthClient {
+
+    /**
+     * OAuth2 로 사용자 정보를 가져온다.
+     */
+    OAuthResponse fetchInfo(String token);
+
+    AuthType getType();
+}

--- a/src/main/java/org/leisureup/global/auth/social/OAuthResponse.java
+++ b/src/main/java/org/leisureup/global/auth/social/OAuthResponse.java
@@ -1,0 +1,12 @@
+package org.leisureup.global.auth.social;
+
+public record OAuthResponse(
+        Long socialId,
+        String name,
+        String email
+) {
+
+    public static OAuthResponse of(Long socialId, String name, String email) {
+        return new OAuthResponse(socialId, name, email);
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/social/SocialAuthService.java
+++ b/src/main/java/org/leisureup/global/auth/social/SocialAuthService.java
@@ -1,0 +1,76 @@
+package org.leisureup.global.auth.social;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import lombok.extern.slf4j.*;
+import org.leisureup.global.auth.dto.*;
+import org.leisureup.global.auth.dto.request.*;
+import org.leisureup.global.auth.dto.request.SignInUpRequest.*;
+import org.leisureup.global.auth.dto.response.*;
+import org.leisureup.global.auth.token.service.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Slf4j
+@Service
+public class SocialAuthService {
+
+    private final MemberSpi memberSpi;
+    private final Map<AuthType, OAuthClient> oauthClients;
+    private final TokenAuthService tokenAuthService;
+
+    public SocialAuthService(
+            MemberSpi memberSpi, List<OAuthClient> oauthClients,
+            TokenAuthService tokenAuthService
+    ) {
+        this.memberSpi = memberSpi;
+        this.oauthClients = oauthClients.stream().collect(
+                Collectors.toMap(OAuthClient::getType, Function.identity())
+        );
+        this.tokenAuthService = tokenAuthService;
+    }
+
+    private static SocialType getType(AuthType authType) {
+        return switch (authType) {
+            case APPLE -> SocialType.APPLE;
+            case GOOGLE -> SocialType.GOOGLE;
+            case KAKAO -> SocialType.KAKAO;
+        };
+    }
+
+    /**
+     * 소셜 인증 token 을 통해 로그인하거나 회원가입한다.
+     */
+    @Transactional(readOnly = true)
+    public SignInUpResponse signInOrSignUp(SignInUpRequest req) {
+
+        // OAuth 로 사용자 정보를 가져온다.
+        AuthType authType = req.authType();
+        OAuthResponse oauthResponse = oauthClients.get(authType)
+                .fetchInfo(req.token());
+        Long socialId = oauthResponse.socialId();
+
+        // 사용자가 가입되어 있는지 아닌지 확인한다.
+        SocialType socialType = getType(authType);
+        Long memberId = memberSpi.getMemberIdWithSocial(socialType, socialId)
+                .orElse(null);
+
+        Tokens tokens;
+
+        if (memberId != null) {     // 가입되어 있으면 토큰을 생성한다.
+            tokens = tokenAuthService.createTokens(memberId);
+            memberId = null;
+        } else {                    // 가입되어 있지 않으면 사용자를 생성하고 토큰을 생성한다.
+            memberId = memberSpi.saveNewMember(
+                    socialType, socialId,
+                    oauthResponse.name(), oauthResponse.email()
+            );
+            tokens = tokenAuthService.createTokens(memberId);
+        }
+
+        return SignInUpResponse.of(memberId, tokens.accessToken(), tokens.refreshToken());
+    }
+
+}

--- a/src/main/java/org/leisureup/global/auth/token/internal/AbstractJwtProvider.java
+++ b/src/main/java/org/leisureup/global/auth/token/internal/AbstractJwtProvider.java
@@ -1,0 +1,30 @@
+package org.leisureup.global.auth.token.internal;
+
+import java.util.*;
+
+public abstract class AbstractJwtProvider extends JwtUtil {
+
+    private static final String MEMBER_ID_SUBJECT_KEY
+            = "MEMBER_ID";
+
+    protected AbstractJwtProvider(String key, long expiration) {
+        super(key, expiration);
+    }
+
+    /**
+     * ID 정보가 담긴 Jwt 를 생성
+     */
+    public final String create(Long memberId) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put(MEMBER_ID_SUBJECT_KEY, memberId);
+
+        return super.create(payload);
+    }
+
+    /**
+     * Jwt 에서 ID 정보를 추출
+     */
+    public final Optional<Long> getMemberId(String token) {
+        return super.getSubject(token, MEMBER_ID_SUBJECT_KEY, Long.class);
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/token/internal/AccessJwtProvider.java
+++ b/src/main/java/org/leisureup/global/auth/token/internal/AccessJwtProvider.java
@@ -1,0 +1,20 @@
+package org.leisureup.global.auth.token.internal;
+
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
+
+/**
+ * Access token 발급, 파싱을 위한 component
+ */
+@Component
+public class AccessJwtProvider extends AbstractJwtProvider {
+
+    public AccessJwtProvider(
+            @Value("${secret.jwt.access-token.key}")
+            String key,
+            @Value("${secret.jwt.access-token.expiration}")
+            long expiration
+    ) {
+        super(key, expiration);
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/token/internal/InvalidTokenException.java
+++ b/src/main/java/org/leisureup/global/auth/token/internal/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package org.leisureup.global.auth.token.internal;
+
+import org.leisureup.global.exception.*;
+
+public class InvalidTokenException extends CustomException {
+
+    public InvalidTokenException(int code) {
+        super(code, "Invalid token");
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/token/internal/JwtUtil.java
+++ b/src/main/java/org/leisureup/global/auth/token/internal/JwtUtil.java
@@ -1,0 +1,107 @@
+package org.leisureup.global.auth.token.internal;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.*;
+import java.time.*;
+import java.util.*;
+import javax.crypto.*;
+import lombok.extern.slf4j.*;
+
+@Slf4j
+public class JwtUtil {
+
+    // jwt secret key
+    private final SecretKey key;
+
+    // 만료기간 초단위
+    private final long expiration;
+
+    protected JwtUtil(String key, long expiration) {
+        this.key = Keys.hmacShaKeyFor(key.getBytes());
+        this.expiration = expiration;
+    }
+
+    // 주어진 걸로 토큰 생성해
+    protected final String create(Map<String, Object> subjects) {
+        Claims claims = Util.buildClaims(subjects, expiration);
+
+        return Jwts.builder()
+                .claims(claims)
+                .signWith(key)
+                .compact();
+    }
+
+    // 토큰에서 값 가져와
+    protected final <T> Optional<T> getSubject(
+            String token, String subjectKey, Class<T> subjectValueClazz
+    ) {
+        T subject = null;
+
+        try {
+            Optional<Claims> optional = Util.getClaims(key, token);
+
+            if (optional.isPresent()) {
+                subject = optional.get().get(subjectKey, subjectValueClazz);
+
+                if (subject == null) {
+                    log.warn("Subject key exists in token, but value is empty.");
+                }
+            } else {
+                log.warn("Invalid token given. Cannot extract subject.");
+            }
+
+        } catch (RequiredTypeException e) {
+            log.warn(
+                    "Incompatible value clazz given. Subject cannot be supplied."
+            );
+        } catch (Exception e) {
+            log.error(
+                    "Unexpected error occurred while parsing jwt : {}",
+                    e.getClass().getSimpleName(),
+                    e
+            );
+        }
+
+        return Optional.ofNullable(subject);
+    }
+}
+
+@Slf4j
+class Util {
+
+    static Date now() {
+        return Date.from(Instant.now());
+    }
+
+    static Date after(long expiration) {
+        return Date.from(Instant.now().plusSeconds(expiration));
+    }
+
+    static Claims buildClaims(
+            Map<String, ?> subjects, long expiration
+    ) {
+        return Jwts.claims()
+                .add(subjects)
+                .issuedAt(Util.now())
+                .expiration(Util.after(expiration))
+                .build();
+    }
+
+    static Optional<Claims> getClaims(
+            SecretKey key, String token
+    ) {
+        Claims claims = null;
+        try {
+            claims = Jwts.parser().verifyWith(key).build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to parse JWT token : {}",
+                    e.getClass().getSimpleName(), e
+            );
+        }
+
+        return Optional.ofNullable(claims);
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/token/internal/RefreshJwtProvider.java
+++ b/src/main/java/org/leisureup/global/auth/token/internal/RefreshJwtProvider.java
@@ -1,0 +1,20 @@
+package org.leisureup.global.auth.token.internal;
+
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
+
+/**
+ * Refresh token 발급, 파싱을 위한 component
+ */
+@Component
+public class RefreshJwtProvider extends AbstractJwtProvider {
+
+    protected RefreshJwtProvider(
+            @Value("${secret.jwt.refresh-token.key}")
+            String key,
+            @Value("${secret.jwt.refresh-token.expiration}")
+            long expiration
+    ) {
+        super(key, expiration);
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/token/repository/RefreshToken.java
+++ b/src/main/java/org/leisureup/global/auth/token/repository/RefreshToken.java
@@ -1,0 +1,24 @@
+package org.leisureup.global.auth.token.repository;
+
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.redis.core.*;
+
+@Getter
+@RedisHash(value = "refresh-token", timeToLive = 360000)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    private Long memberId;
+    private String token;
+
+    private RefreshToken(Long memberId, String token) {
+        this.memberId = memberId;
+        this.token = token;
+    }
+
+    public static RefreshToken of(Long memberId, String token) {
+        return new RefreshToken(memberId, token);
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/leisureup/global/auth/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package org.leisureup.global.auth.token.repository;
+
+import org.springframework.data.repository.*;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+
+}

--- a/src/main/java/org/leisureup/global/auth/token/service/TokenAuthService.java
+++ b/src/main/java/org/leisureup/global/auth/token/service/TokenAuthService.java
@@ -1,0 +1,80 @@
+package org.leisureup.global.auth.token.service;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.global.auth.dto.*;
+import org.leisureup.global.auth.token.internal.*;
+import org.leisureup.global.auth.token.repository.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Service
+@RequiredArgsConstructor
+public class TokenAuthService {
+
+    private final RefreshTokenRepository refreshTokenRepo;
+    private final AccessJwtProvider atProvider;
+    private final RefreshJwtProvider rtProvider;
+    private final MemberSpi memberSpi;
+
+    /**
+     * Refresh token 이 유효한지 검사해 ID 를 추출한다.
+     * <p>
+     * 다음 상황에서 에러가 발생한다.
+     * <li>토큰이 비어있거나 우리가 발급한 토큰이 아님</li>
+     * <li>Redis 에 해당 토큰이 저장되어 있지 않거나 일치하지 않음</li>
+     * <li>토큰은 유효하나 파싱된 ID 에 해당하는 사용자가 없음</li>
+     */
+    public Long getMemberIdFromRt(String refreshToken) {
+
+        // invalid token
+        Long memberId = rtProvider.getMemberId(refreshToken)
+                .orElseThrow(() -> new InvalidTokenException(401));
+
+        Optional<RefreshToken> storedRT = refreshTokenRepo.findById(memberId);
+
+        // token or member not exists
+        if (storedRT.isEmpty() || memberSpi.notExists(memberId)) {
+            throw new NotFound("Not found");
+        }
+
+        // token mismatch
+        if (!refreshToken.equals(storedRT.get().getToken())) {
+            throw new InvalidTokenException(401);
+        }
+
+        return memberId;
+    }
+
+    /**
+     * Access token 이 유효한지 검사해 ID 를 추출한다.
+     * <p>
+     * 다음 상황에서 에러가 발생한다.
+     * <li>토큰이 비어있거나 우리가 발급한 토큰이 아님</li>
+     * <li>토큰은 유효하나 파싱된 ID 에 해당하는 사용자가 없음</li>
+     */
+    public Long getMemberIdFromAt(String accessToken) {
+
+        // invalid token
+        Long memberId = atProvider.getMemberId(accessToken)
+                .orElseThrow(() -> new InvalidTokenException(401));
+
+        // member not exists
+        if (memberSpi.notExists(memberId)) {
+            throw new NotFound("Not found");
+        }
+
+        return memberId;
+    }
+
+    /**
+     * ID 정보가 담긴 토큰들을 생성
+     */
+    public Tokens createTokens(Long memberId) {
+        String at = atProvider.create(memberId);
+        String rt = rtProvider.create(memberId);
+
+        return Tokens.of(at, rt);
+    }
+}

--- a/src/main/java/org/leisureup/global/exception/BadRequestException.java
+++ b/src/main/java/org/leisureup/global/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package org.leisureup.global.exception;
+
+public class BadRequestException extends CustomException {
+
+    public BadRequestException(String message) {
+        super(400, message);
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -1,8 +1,80 @@
 package org.leisureup.member.internal.controller;
 
+import jakarta.validation.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.global.response.*;
+import org.leisureup.member.internal.dto.request.*;
+import org.leisureup.member.internal.dto.response.*;
+import org.leisureup.member.internal.service.*;
+import org.springframework.data.domain.*;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
 public class MemberController {
 
+    // TODO : Request header 의 jwt 로 member id 가져오는 기능 필요
+
+    private final MemberService memberService;
+
+    private static PageRequest toPageRequest(int page, int size) {
+
+        if (page < 0 || size <= 0) {
+            throw new BadRequestException("Bad request");
+        }
+
+        return PageRequest.of(page, Math.min(size, 100));
+    }
+
+    // 멤버 정보 조회
+    @GetMapping
+    public ApiResponse<GetMemberResponse> getMember() {
+        // TODO : 완성하기
+        throw new NotImplemented("API /member not implemented yet");
+    }
+
+    // 니즈 수집 질문 응답 저장
+    @PostMapping("/interest")
+    public ApiResponse<?> saveInterest(
+            @Valid @RequestBody
+            SaveInterestRequest req
+    ) {
+        // TODO : 완성하기
+        throw new NotImplemented("API /member/interest not implemented yet");
+    }
+
+    // 찜 목록 조회
+    @GetMapping("/picks")
+    public ApiResponse<PageResponse<PickLocation>> getPickLocations(
+            @RequestParam(value = "page", defaultValue = "0")
+            int page,
+            @RequestParam(value = "size", defaultValue = "10")
+            int size
+    ) {
+        PageRequest req = toPageRequest(page, size);
+        // TODO : 완성하기
+        throw new NotImplemented("API /member/picks (GET) not implemented yet");
+    }
+
+    // 장소 찜 저장
+    @PostMapping("/picks")
+    public ApiResponse<?> savePickLocation(
+            @Valid SavePickLocationRequest req
+    ) {
+        // TODO : 완성하기
+        throw new NotImplemented("API /member/picks (POST) not implemented yet");
+    }
+
+    // 찜 장소 삭제
+    @DeleteMapping("/picks/{locationId}")
+    public ApiResponse<?> deletePickLocation(
+            @Valid @Positive @NotNull
+            @PathVariable Long locationId
+    ) {
+        // TODO : 완성하기
+        throw new NotImplemented("API /member/pick/{locationId} not implemented yet");
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/AppleOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/AppleOAuth.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class AppleOAuth extends BaseTimeEntity {
 
     @Id
@@ -17,4 +18,8 @@ public class AppleOAuth extends BaseTimeEntity {
     @OneToOne(optional = false)
     @JoinColumn(name = "member_id", nullable = false, updatable = false)
     private Member member;
+
+    public static AppleOAuth of(Long socialId, Member member) {
+        return new AppleOAuth(socialId, member);
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/AppleOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/AppleOAuth.java
@@ -1,0 +1,20 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Apple 소셜 인증 정보를 저장할 엔티티
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppleOAuth extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private Member member;
+}

--- a/src/main/java/org/leisureup/member/internal/domain/BaseTimeEntity.java
+++ b/src/main/java/org/leisureup/member/internal/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import java.time.*;
+import lombok.*;
+import org.springframework.data.annotation.*;
+import org.springframework.data.jpa.domain.support.*;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime lastModifiedAt;
+}

--- a/src/main/java/org/leisureup/member/internal/domain/GoogleOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/GoogleOAuth.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class GoogleOAuth extends BaseTimeEntity {
 
     @Id
@@ -18,4 +19,7 @@ public class GoogleOAuth extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false, updatable = false)
     private Member member;
 
+    public static GoogleOAuth of(Long socialId, Member member) {
+        return new GoogleOAuth(socialId, member);
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/GoogleOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/GoogleOAuth.java
@@ -1,0 +1,21 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Google 소셜 인증 정보를 저장할 엔티티
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoogleOAuth extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private Member member;
+
+}

--- a/src/main/java/org/leisureup/member/internal/domain/Interest.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Interest.java
@@ -1,0 +1,26 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자 니즈 수집 질문을 저장하는 엔티티
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Interest {
+
+    @Id
+    private Long memberId;
+
+    @MapsId
+    @OneToOne(optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Setter
+    @Embedded
+    private InterestInfo info;
+
+}

--- a/src/main/java/org/leisureup/member/internal/domain/Interest.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Interest.java
@@ -23,4 +23,10 @@ public class Interest {
     @Embedded
     private InterestInfo info;
 
+    public static Interest of(Member member, InterestInfo info) {
+        Interest interest = new Interest();
+        interest.member = member;
+        interest.info = InterestInfo.of(info);
+        return interest;
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/InterestInfo.java
+++ b/src/main/java/org/leisureup/member/internal/domain/InterestInfo.java
@@ -1,0 +1,58 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자 니즈 수집 응답 세부사항
+ */
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterestInfo {
+
+    private int ageRange;
+
+    @Enumerated(EnumType.STRING)
+    private With with;
+
+    @Enumerated(EnumType.STRING)
+    private Experience experience;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    @Enumerated(EnumType.STRING)
+    private LeisureType leisureType;
+
+    @Enumerated(EnumType.STRING)
+    private PreferredSeason preferredSeason;
+
+    @Enumerated(EnumType.STRING)
+    private Difficulty difficulty;
+
+    public enum With {
+        alone, friend, family
+    }
+
+    public enum Experience {
+        first, couple, several
+    }
+
+    public enum Type {
+        relieving, thrilling
+    }
+
+    public enum LeisureType {
+        water, earth, sky, any
+    }
+
+    public enum PreferredSeason {
+        spring, summer, autumn, winter, any
+    }
+
+    public enum Difficulty {
+        low, medium, high
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/domain/InterestInfo.java
+++ b/src/main/java/org/leisureup/member/internal/domain/InterestInfo.java
@@ -2,6 +2,10 @@ package org.leisureup.member.internal.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.leisureup.member.internal.domain.InterestInfo.*;
+import org.leisureup.member.internal.domain.InterestInfo.With;
+import org.leisureup.member.internal.dto.request.*;
+import org.leisureup.member.internal.dto.request.SaveInterestRequest.*;
 
 /**
  * 사용자 니즈 수집 응답 세부사항
@@ -32,6 +36,34 @@ public class InterestInfo {
     @Enumerated(EnumType.STRING)
     private Difficulty difficulty;
 
+    public static InterestInfo of(SaveInterestRequest request) {
+        int age = request.ageRange();
+        var reqWith = request.with();
+        var reqExp = request.experience();
+        var reqType = request.type();
+        var reqLeisureType = request.leisureType();
+        var reqSeason = request.preferredSeason();
+        var reqDifficulty = request.difficulty();
+
+        return new InterestInfo(
+                age,
+                Util.with(reqWith), Util.experience(reqExp),
+                Util.type(reqType), Util.leisureType(reqLeisureType),
+                Util.preferredSeason(reqSeason), Util.difficulty(reqDifficulty)
+        );
+    }
+
+    public static InterestInfo of(InterestInfo given) {
+        InterestInfo info = new InterestInfo();
+        info.with = given.with;
+        info.experience = given.experience;
+        info.leisureType = given.leisureType;
+        info.preferredSeason = given.preferredSeason;
+        info.difficulty = given.difficulty;
+        info.type = given.type;
+        return info;
+    }
+
     public enum With {
         alone, friend, family
     }
@@ -54,5 +86,58 @@ public class InterestInfo {
 
     public enum Difficulty {
         low, medium, high
+    }
+}
+
+class Util {
+
+    static With with(ReqWith reqWith) {
+        return switch (reqWith) {
+            case alone -> With.alone;
+            case friend -> With.friend;
+            case family -> With.family;
+        };
+    }
+
+    static Experience experience(ReqExperience reqExp) {
+        return switch (reqExp) {
+            case first -> Experience.first;
+            case couple -> Experience.couple;
+            case several -> Experience.several;
+        };
+    }
+
+    static Type type(ReqType reqType) {
+        return switch (reqType) {
+            case relieving -> Type.relieving;
+            case thrilling -> Type.thrilling;
+        };
+    }
+
+    static LeisureType leisureType(ReqLeisureType reqLeisureType) {
+        return switch (reqLeisureType) {
+            case water -> LeisureType.water;
+            case earth -> LeisureType.earth;
+            case sky -> LeisureType.sky;
+            case any -> LeisureType.any;
+        };
+    }
+
+    static PreferredSeason preferredSeason(ReqPreferredSeason reqSeason) {
+        return switch (reqSeason) {
+            case spring -> PreferredSeason.spring;
+            case summer -> PreferredSeason.summer;
+            case autumn -> PreferredSeason.autumn;
+            case winter -> PreferredSeason.winter;
+            case any -> PreferredSeason.any;
+        };
+    }
+
+    static Difficulty difficulty(ReqDifficulty reqDifficulty) {
+        return switch (reqDifficulty) {
+            case low -> Difficulty.low;
+            case medium -> Difficulty.medium;
+            case high -> Difficulty.high;
+        };
     }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/KakaoOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/KakaoOAuth.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class KakaoOAuth extends BaseTimeEntity {
 
     @Id
@@ -18,4 +19,7 @@ public class KakaoOAuth extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false, updatable = false)
     private Member member;
 
+    public static KakaoOAuth of(Long socialId, Member member) {
+        return new KakaoOAuth(socialId, member);
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/KakaoOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/KakaoOAuth.java
@@ -1,0 +1,21 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Kakao 소셜 인증 정보를 저장할 엔티티
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoOAuth extends BaseTimeEntity {
+
+    @Id
+    private Long id;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private Member member;
+
+}

--- a/src/main/java/org/leisureup/member/internal/domain/Member.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Member.java
@@ -1,0 +1,26 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickname;
+    private String email;
+
+    private Member(String nickname, String email) {
+        this.nickname = nickname;
+        this.email = email;
+    }
+
+    public static Member of(String nickname, String email) {
+        return new Member(nickname, email);
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/domain/Pick.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Pick.java
@@ -1,0 +1,23 @@
+package org.leisureup.member.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자 찜 목록을 저장할 엔티티
+ */
+@Getter
+@Entity
+@IdClass(PickCompositeKey.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Pick extends BaseTimeEntity {
+
+    @Id
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "a_member_id", nullable = false, updatable = false)
+    private Member member;
+
+    @Id
+    @Column(name = "b_location_id", nullable = false, updatable = false)
+    private long locationId;
+}

--- a/src/main/java/org/leisureup/member/internal/domain/PickCompositeKey.java
+++ b/src/main/java/org/leisureup/member/internal/domain/PickCompositeKey.java
@@ -1,0 +1,15 @@
+package org.leisureup.member.internal.domain;
+
+import lombok.*;
+
+/**
+ * 사용자 찜 목록 저장용 복합키
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class PickCompositeKey {
+
+    private Member member;
+    private long locationId;
+}

--- a/src/main/java/org/leisureup/member/internal/dto/request/SaveInterestRequest.java
+++ b/src/main/java/org/leisureup/member/internal/dto/request/SaveInterestRequest.java
@@ -1,0 +1,39 @@
+package org.leisureup.member.internal.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record SaveInterestRequest(
+        @Positive int ageRange,
+
+        @NotNull ReqWith with,
+        @NotNull ReqExperience experience,
+        @NotNull ReqType type,
+        @NotNull ReqLeisureType leisureType,
+        @NotNull ReqPreferredSeason preferredSeason,
+        @NotNull ReqDifficulty difficulty
+) {
+
+    public enum ReqWith {
+        alone, friend, family
+    }
+
+    public enum ReqExperience {
+        first, couple, several
+    }
+
+    public enum ReqType {
+        relieving, thrilling
+    }
+
+    public enum ReqLeisureType {
+        water, earth, sky, any
+    }
+
+    public enum ReqPreferredSeason {
+        spring, summer, autumn, winter, any
+    }
+
+    public enum ReqDifficulty {
+        low, medium, high
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/dto/request/SavePickLocationRequest.java
+++ b/src/main/java/org/leisureup/member/internal/dto/request/SavePickLocationRequest.java
@@ -1,0 +1,10 @@
+package org.leisureup.member.internal.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record SavePickLocationRequest(
+        @NotNull @Positive
+        Long locationId
+) {
+
+}

--- a/src/main/java/org/leisureup/member/internal/dto/response/GetMemberResponse.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/GetMemberResponse.java
@@ -1,0 +1,15 @@
+package org.leisureup.member.internal.dto.response;
+
+import org.leisureup.member.internal.domain.*;
+
+public record GetMemberResponse(
+        String nickname,
+        String email
+) {
+
+    public static GetMemberResponse of(Member member) {
+        return new GetMemberResponse(
+                member.getNickname(), member.getEmail()
+        );
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/dto/response/PageResponse.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/PageResponse.java
@@ -1,0 +1,13 @@
+package org.leisureup.member.internal.dto.response;
+
+import java.util.*;
+
+public record PageResponse<T>(
+        long totalPages,
+        int pageNo,
+        int pageSize,
+        boolean lastPage,
+        List<T> elements
+) {
+
+}

--- a/src/main/java/org/leisureup/member/internal/dto/response/PickLocation.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/PickLocation.java
@@ -1,0 +1,14 @@
+package org.leisureup.member.internal.dto.response;
+
+public record PickLocation(
+        Long id,
+        String name,
+        String largeThumbnail,
+        String smallThumbnail,
+        Category category
+) {
+
+    public enum Category {
+        EARTH, WATER, SKY, OTHER
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
@@ -8,8 +8,8 @@ public interface AppleOAuthRepository
         extends JpaRepository<AppleOAuth, Long> {
 
     @Query("""
-            select mid from AppleOAuth ao
-            right join ao.member.id mid
+            select m.id from AppleOAuth ao
+            right join ao.member m
             where ao.id = :socialId
             """)
     Optional<Long> findMemberIdBySocial(Long socialId);

--- a/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
@@ -1,0 +1,16 @@
+package org.leisureup.member.internal.repository;
+
+import java.util.*;
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface AppleOAuthRepository
+        extends JpaRepository<AppleOAuth, Long> {
+
+    @Query("""
+            select mid from AppleOAuth ao
+            right join ao.member.id mid
+            where ao.id = :socialId
+            """)
+    Optional<Long> findMemberIdBySocial(Long socialId);
+}

--- a/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
@@ -8,8 +8,8 @@ public interface GoogleOAuthRepository
         extends JpaRepository<GoogleOAuth, Long> {
 
     @Query("""
-            select mid from GoogleOAuth go
-            right join go.member.id mid
+            select m.id from GoogleOAuth go
+            right join go.member m
             where go.id = :socialId
             """)
     Optional<Long> findMemberIdBySocial(Long socialId);

--- a/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
@@ -1,0 +1,16 @@
+package org.leisureup.member.internal.repository;
+
+import java.util.*;
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface GoogleOAuthRepository
+        extends JpaRepository<GoogleOAuth, Long> {
+
+    @Query("""
+            select mid from GoogleOAuth go
+            right join go.member.id mid
+            where go.id = :socialId
+            """)
+    Optional<Long> findMemberIdBySocial(Long socialId);
+}

--- a/src/main/java/org/leisureup/member/internal/repository/InterestRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/InterestRepository.java
@@ -1,0 +1,8 @@
+package org.leisureup.member.internal.repository;
+
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface InterestRepository extends JpaRepository<Interest, Long> {
+
+}

--- a/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
@@ -8,8 +8,8 @@ public interface KakaoOAuthRepository
         extends JpaRepository<KakaoOAuth, Long> {
 
     @Query("""
-            select mid from KakaoOAuth ko
-            right join ko.member.id mid
+            select m.id from KakaoOAuth ko
+            right join ko.member m
             where ko.id = :socialId
             """)
     Optional<Long> findMemberIdBySocial(Long socialId);

--- a/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
@@ -1,0 +1,16 @@
+package org.leisureup.member.internal.repository;
+
+import java.util.*;
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface KakaoOAuthRepository
+        extends JpaRepository<KakaoOAuth, Long> {
+
+    @Query("""
+            select mid from KakaoOAuth ko
+            right join ko.member.id mid
+            where ko.id = :socialId
+            """)
+    Optional<Long> findMemberIdBySocial(Long socialId);
+}

--- a/src/main/java/org/leisureup/member/internal/repository/MemberRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package org.leisureup.member.internal.repository;
+
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/org/leisureup/member/internal/service/MemberService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberService.java
@@ -1,0 +1,49 @@
+package org.leisureup.member.internal.service;
+
+import jakarta.transaction.*;
+import java.util.*;
+import lombok.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.member.internal.domain.*;
+import org.leisureup.member.internal.dto.request.*;
+import org.leisureup.member.internal.dto.response.*;
+import org.leisureup.member.internal.repository.*;
+import org.springframework.stereotype.*;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepo;
+    private final InterestRepository interestRepo;
+
+    public GetMemberResponse getMember(Long memberId) {
+        Member find = memberRepo.findById(memberId)
+                .orElseThrow(() -> new NotFound("Member not found"));
+
+        return GetMemberResponse.of(find);
+    }
+
+    /**
+     * 사용자 니즈 수집 질문을 저장한다.
+     * <p>
+     * 이전에 응답했으면 수정해 저장한다.
+     */
+    @Transactional
+    public void saveInterest(Long memberId, SaveInterestRequest req) {
+        Member member = memberRepo.findById(memberId)
+                .orElseThrow(() -> new NotFound("Member not found"));
+
+        InterestInfo savingInfo = InterestInfo.of(req);
+        Optional<Interest> optional = interestRepo.findById(memberId);
+
+        if (optional.isPresent()) {
+            Interest interest = optional.get();
+            interest.setInfo(savingInfo);
+            return;
+        }
+
+        interestRepo.save(Interest.of(member, savingInfo));
+    }
+
+}

--- a/src/main/java/org/leisureup/member/spi/MemberSpi.java
+++ b/src/main/java/org/leisureup/member/spi/MemberSpi.java
@@ -1,0 +1,12 @@
+package org.leisureup.member.spi;
+
+import java.util.*;
+
+public interface MemberSpi {
+
+    boolean notExists(Long memberId);
+
+    Optional<Long> getMemberIdWithSocial(
+            SocialType type, Long socialId
+    );
+}

--- a/src/main/java/org/leisureup/member/spi/MemberSpi.java
+++ b/src/main/java/org/leisureup/member/spi/MemberSpi.java
@@ -1,12 +1,28 @@
 package org.leisureup.member.spi;
 
 import java.util.*;
+import org.springframework.transaction.annotation.*;
 
 public interface MemberSpi {
 
+    /**
+     * ID 에 해당하는 사용자가 없는지 확인
+     */
     boolean notExists(Long memberId);
 
+    /**
+     * 주어진 정보로 DB 에 저장된 사용자 ID 를 제공
+     */
     Optional<Long> getMemberIdWithSocial(
             SocialType type, Long socialId
+    );
+
+    /**
+     * 주어진 정보로 새로운 사용자를 생성
+     */
+    @Transactional
+    Long saveNewMember(
+            SocialType type, Long socialId,
+            String nickname, String email
     );
 }

--- a/src/main/java/org/leisureup/member/spi/SocialType.java
+++ b/src/main/java/org/leisureup/member/spi/SocialType.java
@@ -1,0 +1,5 @@
+package org.leisureup.member.spi;
+
+public enum SocialType {
+    APPLE, GOOGLE, KAKAO
+}

--- a/src/main/java/org/leisureup/member/spi/internal/AppleSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/AppleSocialAuth.java
@@ -2,9 +2,11 @@ package org.leisureup.member.spi.internal;
 
 import java.util.*;
 import lombok.*;
+import org.leisureup.member.internal.domain.*;
 import org.leisureup.member.internal.repository.*;
 import org.leisureup.member.spi.*;
 import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
 @Component
 @RequiredArgsConstructor
@@ -20,5 +22,11 @@ public class AppleSocialAuth implements SocialAuth {
     @Override
     public SocialType getSocialAuthType() {
         return SocialType.APPLE;
+    }
+
+    @Override
+    @Transactional
+    public void save(Long socialId, Member member) {
+        repository.save(AppleOAuth.of(socialId, member));
     }
 }

--- a/src/main/java/org/leisureup/member/spi/internal/AppleSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/AppleSocialAuth.java
@@ -1,0 +1,24 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Component
+@RequiredArgsConstructor
+public class AppleSocialAuth implements SocialAuth {
+
+    private final AppleOAuthRepository repository;
+
+    @Override
+    public Optional<Long> findMemberIdBySocial(Long socialId) {
+        return repository.findMemberIdBySocial(socialId);
+    }
+
+    @Override
+    public SocialType getSocialAuthType() {
+        return SocialType.APPLE;
+    }
+}

--- a/src/main/java/org/leisureup/member/spi/internal/GoogleSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/GoogleSocialAuth.java
@@ -1,0 +1,24 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleSocialAuth implements SocialAuth {
+
+    private final GoogleOAuthRepository repository;
+
+    @Override
+    public Optional<Long> findMemberIdBySocial(Long socialId) {
+        return repository.findMemberIdBySocial(socialId);
+    }
+
+    @Override
+    public SocialType getSocialAuthType() {
+        return SocialType.GOOGLE;
+    }
+}

--- a/src/main/java/org/leisureup/member/spi/internal/GoogleSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/GoogleSocialAuth.java
@@ -2,9 +2,11 @@ package org.leisureup.member.spi.internal;
 
 import java.util.*;
 import lombok.*;
+import org.leisureup.member.internal.domain.*;
 import org.leisureup.member.internal.repository.*;
 import org.leisureup.member.spi.*;
 import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
 @Component
 @RequiredArgsConstructor
@@ -20,5 +22,11 @@ public class GoogleSocialAuth implements SocialAuth {
     @Override
     public SocialType getSocialAuthType() {
         return SocialType.GOOGLE;
+    }
+
+    @Override
+    @Transactional
+    public void save(Long socialId, Member member) {
+        repository.save(GoogleOAuth.of(socialId, member));
     }
 }

--- a/src/main/java/org/leisureup/member/spi/internal/KakaoSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/KakaoSocialAuth.java
@@ -1,0 +1,24 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoSocialAuth implements SocialAuth {
+
+    private final KakaoOAuthRepository repository;
+
+    @Override
+    public Optional<Long> findMemberIdBySocial(Long socialId) {
+        return repository.findMemberIdBySocial(socialId);
+    }
+
+    @Override
+    public SocialType getSocialAuthType() {
+        return SocialType.KAKAO;
+    }
+}

--- a/src/main/java/org/leisureup/member/spi/internal/KakaoSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/KakaoSocialAuth.java
@@ -2,9 +2,11 @@ package org.leisureup.member.spi.internal;
 
 import java.util.*;
 import lombok.*;
+import org.leisureup.member.internal.domain.*;
 import org.leisureup.member.internal.repository.*;
 import org.leisureup.member.spi.*;
 import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
 @Component
 @RequiredArgsConstructor
@@ -20,5 +22,11 @@ public class KakaoSocialAuth implements SocialAuth {
     @Override
     public SocialType getSocialAuthType() {
         return SocialType.KAKAO;
+    }
+
+    @Override
+    @Transactional
+    public void save(Long socialId, Member member) {
+        repository.save(KakaoOAuth.of(socialId, member));
     }
 }

--- a/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
+++ b/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
@@ -1,0 +1,35 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Component
+public class MemberSpiImpl implements MemberSpi {
+
+    private final MemberRepository memberRepo;
+    private final Map<SocialType, SocialAuth> socialAuths;
+
+    public MemberSpiImpl(
+            MemberRepository memberRepo,
+            List<SocialAuth> socialAuths
+    ) {
+        this.memberRepo = memberRepo;
+        this.socialAuths = socialAuths.stream().collect(
+                Collectors.toMap(SocialAuth::getSocialAuthType, Function.identity())
+        );
+    }
+
+    @Override
+    public boolean notExists(Long memberId) {
+        return !memberRepo.existsById(memberId);
+    }
+
+    @Override
+    public Optional<Long> getMemberIdWithSocial(SocialType type, Long socialId) {
+        return socialAuths.get(type).findMemberIdBySocial(socialId);
+    }
+}

--- a/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
+++ b/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
@@ -3,6 +3,7 @@ package org.leisureup.member.spi.internal;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.leisureup.member.internal.domain.*;
 import org.leisureup.member.internal.repository.*;
 import org.leisureup.member.spi.*;
 import org.springframework.stereotype.*;
@@ -31,5 +32,17 @@ public class MemberSpiImpl implements MemberSpi {
     @Override
     public Optional<Long> getMemberIdWithSocial(SocialType type, Long socialId) {
         return socialAuths.get(type).findMemberIdBySocial(socialId);
+    }
+
+    @Override
+    public Long saveNewMember(
+            SocialType type, Long socialId,
+            String nickname, String email
+    ) {
+        Member save = memberRepo.save(Member.of(nickname, email));
+
+        socialAuths.get(type).save(socialId, save);
+
+        return save.getId();
     }
 }

--- a/src/main/java/org/leisureup/member/spi/internal/SocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/SocialAuth.java
@@ -1,0 +1,11 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import org.leisureup.member.spi.*;
+
+public interface SocialAuth {
+
+    Optional<Long> findMemberIdBySocial(Long socialId);
+
+    SocialType getSocialAuthType();
+}

--- a/src/main/java/org/leisureup/member/spi/internal/SocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/SocialAuth.java
@@ -1,11 +1,22 @@
 package org.leisureup.member.spi.internal;
 
 import java.util.*;
+import org.leisureup.member.internal.domain.*;
 import org.leisureup.member.spi.*;
+import org.springframework.transaction.annotation.*;
 
 public interface SocialAuth {
 
+    /**
+     * {@code socialId} 를 통해 DB 에 저장된 사용자 ID 를 제공
+     */
     Optional<Long> findMemberIdBySocial(Long socialId);
 
     SocialType getSocialAuthType();
+
+    /**
+     * 소셜 인증 repository 에 해당 정보를 생성 (회원가입용)
+     */
+    @Transactional
+    void save(Long socialId, Member member);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,7 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+        globally_quoted_identifiers: true
 
   data:
     redis:

--- a/src/test/java/org/leisureup/IntegrationTestSupport.java
+++ b/src/test/java/org/leisureup/IntegrationTestSupport.java
@@ -1,0 +1,8 @@
+package org.leisureup;
+
+import org.springframework.boot.test.context.*;
+
+@SpringBootTest
+public abstract class IntegrationTestSupport {
+
+}

--- a/src/test/java/org/leisureup/JwtAuthTest.java
+++ b/src/test/java/org/leisureup/JwtAuthTest.java
@@ -1,0 +1,88 @@
+package org.leisureup;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.*;
+import org.leisureup.global.auth.token.internal.*;
+import org.leisureup.member.spi.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.autoconfigure.web.servlet.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.http.*;
+import org.springframework.test.context.bean.override.mockito.*;
+import org.springframework.test.web.servlet.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class JwtAuthTest {
+
+    private static final Long memberId = 1L;
+    private static final String AUTH_HEADER =
+            HttpHeaders.AUTHORIZATION;
+    private static String accessToken;
+    @Autowired
+    MockMvc mvc;
+    @Autowired
+    AccessJwtProvider atProvider;
+    @MockitoBean
+    MemberSpi memberSpi;
+
+    @BeforeEach
+    void setUp() {
+        accessToken = atProvider.create(memberId);
+        when(memberSpi.notExists(anyLong()))
+                .thenAnswer(invocation -> {
+                    Long id = invocation.getArgument(0, Long.class);
+                    return !memberId.equals(id);
+                });
+    }
+
+    @Test
+    @DisplayName("토큰이 존재하면 정상 응답을 받는다.")
+    void testAuthenticate() throws Exception {
+
+        mvc.perform(get("/test/auth-required")
+                        .header(
+                                AUTH_HEADER,
+                                "Bearer " + accessToken
+                        )
+                )
+                .andExpect(status().is(200))
+                .andExpect(
+                        jsonPath("$.data")
+                                .value(String.valueOf(memberId))
+                );
+    }
+
+    @Test
+    @DisplayName("토큰이 없으면 비인가 에러 응답을 받는다.")
+    void testUnauthenticate() throws Exception {
+        mvc.perform(get("/test/auth-required"))
+                .andExpect(status().is(401));
+    }
+
+    @Test
+    @DisplayName("토큰이 없어도 처리할 수 있는 응답이 있다.")
+    void testPartialAuthenticate() throws Exception {
+        mvc.perform(get("/test/auth-bypassable")
+                        .header(
+                                AUTH_HEADER,
+                                "Bearer " + accessToken
+                        )
+                )
+                .andExpect(status().is(200))
+                .andExpect(
+                        jsonPath("$.data")
+                                .value(String.valueOf(memberId))
+                );
+
+        mvc.perform(get("/test/auth-bypassable"))
+                .andExpect(status().is(200))
+                .andExpect(
+                        jsonPath("$.data").isEmpty()
+                );
+    }
+}

--- a/src/test/java/org/leisureup/JwtAuthTestController.java
+++ b/src/test/java/org/leisureup/JwtAuthTestController.java
@@ -1,0 +1,32 @@
+package org.leisureup;
+
+import lombok.*;
+import org.leisureup.global.*;
+import org.leisureup.global.response.*;
+import org.springframework.context.annotation.*;
+import org.springframework.web.bind.annotation.*;
+
+@Profile("test")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/test")
+public class JwtAuthTestController {
+
+    // Jwt 인가 테스트용 controller
+
+    private final AuthHolder authHolder;
+
+    @JwtAuthRequired
+    @GetMapping("/auth-required")
+    public ApiResponse<Long> getMemberIdFromJwt() {
+        Long id = authHolder.getMemberId();
+        return ApiResponse.success(200, id);
+    }
+
+    @JwtAuthIfPossible
+    @GetMapping("/auth-bypassable")
+    public ApiResponse<Long> getMemberFromJwt() {
+        Long id = authHolder.getMemberId();
+        return ApiResponse.success(200, id);
+    }
+}

--- a/src/test/java/org/leisureup/LeisureUpTests.java
+++ b/src/test/java/org/leisureup/LeisureUpTests.java
@@ -4,17 +4,30 @@ import lombok.extern.slf4j.*;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.*;
 import org.springframework.modulith.core.*;
+import org.springframework.modulith.docs.*;
 
 @Slf4j
 @SpringBootTest
 class LeisureUpTests {
 
+    private final ApplicationModules modules
+            = ApplicationModules.of(LeisureUp.class);
+
     @Test
     void contextLoads() {
-        ApplicationModules applicationModules = ApplicationModules.of(LeisureUp.class);
 
-        applicationModules.forEach(m -> log.info("Module: {}", m));
-        applicationModules.verify();
     }
 
+    @Test
+    void verifyModules() {
+        modules.forEach(m -> log.info("Module : {}", m));
+        modules.verify();
+    }
+
+    @Test
+    void writeDocument() {
+        new Documenter(modules)
+                .writeModulesAsPlantUml()
+                .writeIndividualModulesAsPlantUml();
+    }
 }

--- a/src/test/java/org/leisureup/global/auth/social/SocialAuthServiceTest.java
+++ b/src/test/java/org/leisureup/global/auth/social/SocialAuthServiceTest.java
@@ -1,0 +1,153 @@
+package org.leisureup.global.auth.social;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.stream.*;
+import lombok.extern.slf4j.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.leisureup.*;
+import org.leisureup.global.auth.dto.request.*;
+import org.leisureup.global.auth.dto.request.SignInUpRequest.*;
+import org.leisureup.global.auth.token.internal.*;
+import org.leisureup.member.internal.domain.*;
+import org.leisureup.member.internal.repository.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.test.context.bean.override.mockito.*;
+
+@Slf4j
+class SocialAuthServiceTest extends IntegrationTestSupport {
+
+    private static final String preAssignedToken = "사용자는 이전에 가입했었다.";
+    private static final String newSocialToken = "사용자는 현재 처음 가입중이다.";
+    private static final Long kakaoSignIn = 1L, kakaoSignUp = 2L;
+    private static final Long appleSignIn = 3L, appleSignUp = 4L;
+    private static final Long googleSignIn = 5L, googleSignUp = 6L;
+    private static Long memberId;
+    @Autowired
+    SocialAuthService socialAuthService;
+    @Autowired
+    MemberRepository memberRepo;
+    @Autowired
+    KakaoOAuthRepository kakaoOAuthRepo;
+    @Autowired
+    AppleOAuthRepository appleOAuthRepo;
+    @Autowired
+    GoogleOAuthRepository googleOAuthRepo;
+    @Autowired
+    AccessJwtProvider accessJwtProvider;
+    @Autowired
+    RefreshJwtProvider refreshJwtProvider;
+    @MockitoSpyBean
+    KakaoOAuthClient kakaoOAuthClient;
+    @MockitoSpyBean
+    AppleOAuthClient appleOAuthClient;
+    @MockitoSpyBean
+    GoogleOAuthClient googleOAuthClient;
+
+    private static Stream<Arguments> signInRequests() {
+        return Stream.of(
+                Arguments.of(new SignInUpRequest(AuthType.KAKAO, preAssignedToken)),
+                Arguments.of(new SignInUpRequest(AuthType.APPLE, preAssignedToken)),
+                Arguments.of(new SignInUpRequest(AuthType.GOOGLE, preAssignedToken))
+        );
+    }
+
+    private static Stream<Arguments> signUpRequests() {
+        return Stream.of(
+                Arguments.of(new SignInUpRequest(AuthType.KAKAO, newSocialToken)),
+                Arguments.of(new SignInUpRequest(AuthType.APPLE, newSocialToken)),
+                Arguments.of(new SignInUpRequest(AuthType.GOOGLE, newSocialToken))
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+
+        setupOAuthClientMock(kakaoSignIn, kakaoSignUp, kakaoOAuthClient);
+        setupOAuthClientMock(googleSignIn, googleSignUp, googleOAuthClient);
+        setupOAuthClientMock(appleSignIn, appleSignUp, appleOAuthClient);
+
+        var member = memberRepo.save(Member.of("test", "test"));
+        kakaoOAuthRepo.save(KakaoOAuth.of(kakaoSignIn, member));
+        appleOAuthRepo.save(AppleOAuth.of(appleSignIn, member));
+        googleOAuthRepo.save(GoogleOAuth.of(googleSignIn, member));
+
+        memberId = member.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        kakaoOAuthRepo.deleteAll();
+        appleOAuthRepo.deleteAll();
+        googleOAuthRepo.deleteAll();
+        memberRepo.deleteAll();
+    }
+
+    @ParameterizedTest
+    @MethodSource("signInRequests")
+    @DisplayName("이미 가입한 유저는 소셜 인증을 통해 로그인할 수 있다.")
+    void signIn(SignInUpRequest req) {
+        var response = socialAuthService.signInOrSignUp(req);
+
+        assertThat(response).isNotNull();
+        assertThat(response).satisfies(
+                r -> assertThat(r.id()).isNull(),
+                r -> assertThat(r.accessToken()).isNotBlank(),
+                r -> assertThat(r.refreshToken()).isNotBlank()
+        );
+
+        String at = response.accessToken();
+        String rt = response.refreshToken();
+
+        assertThat(accessJwtProvider.getMemberId(at)).isPresent()
+                .get().isEqualTo(memberId);
+        assertThat(refreshJwtProvider.getMemberId(rt)).isPresent()
+                .get().isEqualTo(memberId);
+    }
+
+    @ParameterizedTest
+    @MethodSource("signUpRequests")
+    @DisplayName("가입하지 않은 사용자는 소셜 인증을 통해 가입할 수 있다.")
+    void signUp(SignInUpRequest req) {
+        log.info("start");
+        var response = socialAuthService.signInOrSignUp(req);
+        Long newMemberId = response.id();
+
+        assertThat(response).isNotNull();
+        assertThat(newMemberId).isNotNull();
+        assertThat(response).satisfies(
+                r -> assertThat(r.accessToken()).isNotBlank(),
+                r -> assertThat(r.refreshToken()).isNotBlank()
+        );
+
+        String at = response.accessToken();
+        String rt = response.refreshToken();
+
+        assertThat(accessJwtProvider.getMemberId(at)).isPresent()
+                .get().isEqualTo(newMemberId);
+        assertThat(refreshJwtProvider.getMemberId(rt)).isPresent()
+                .get().isEqualTo(newMemberId);
+
+        assertThat(memberRepo.findById(newMemberId))
+                .isPresent();
+    }
+
+    void setupOAuthClientMock(Long idOnSignIn, Long idOnSignUp, OAuthClient client) {
+        when(client.fetchInfo(anyString()))
+                .thenAnswer(invocation -> {
+                    String token = invocation.getArgument(0, String.class);
+
+                    if (preAssignedToken.equals(token)) {
+                        return OAuthResponse.of(idOnSignIn, "signIn", "signIn");
+                    } else if (newSocialToken.equals(token)) {
+                        return OAuthResponse.of(idOnSignUp, "signUp", "signUp");
+                    }
+
+                    throw new RuntimeException();
+                });
+    }
+}

--- a/src/test/java/org/leisureup/global/auth/token/service/TokenAuthServiceTest.java
+++ b/src/test/java/org/leisureup/global/auth/token/service/TokenAuthServiceTest.java
@@ -1,0 +1,108 @@
+package org.leisureup.global.auth.token.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import lombok.extern.slf4j.*;
+import org.junit.jupiter.api.*;
+import org.leisureup.*;
+import org.leisureup.global.auth.token.internal.*;
+import org.leisureup.global.auth.token.repository.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.member.spi.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.test.context.bean.override.mockito.*;
+
+@Slf4j
+class TokenAuthServiceTest extends IntegrationTestSupport {
+
+    private static final Long existMemberId1 = 1L,
+            existMemberId2 = 2L,
+            notExistMemberId = 3L;
+    private static final String invalidToken = "invalid";
+    private static String validAT, validRT;
+    private static String invalidMemberIdAt, invalidMemberIdRt;
+    private static String validRtButNotRegistered;
+    @Autowired
+    TokenAuthService tokenAuthService;
+    @Autowired
+    AccessJwtProvider atProvider;
+    @Autowired
+    RefreshJwtProvider rtProvider;
+    @MockitoBean
+    RefreshTokenRepository refreshTokenRepo;
+    @MockitoBean
+    MemberSpi memberSpi;
+
+    @BeforeEach
+    void setUp() {
+
+        validAT = atProvider.create(existMemberId1);
+        validRT = rtProvider.create(existMemberId1);
+        validRtButNotRegistered = rtProvider.create(existMemberId2);
+
+        invalidMemberIdAt = atProvider.create(notExistMemberId);
+        invalidMemberIdRt = rtProvider.create(notExistMemberId);
+
+        when(refreshTokenRepo.findById(anyLong()))
+                .thenAnswer(invocation -> {
+                    Long id = invocation.getArgument(0, Long.class);
+
+                    RefreshToken result = !existMemberId1.equals(id) && !existMemberId2.equals(id) ?
+                            null : RefreshToken.of(id, validRT);
+
+                    return Optional.ofNullable(result);
+                });
+
+        when(memberSpi.notExists(anyLong()))
+                .thenAnswer(invocation -> {
+                    Long id = invocation.getArgument(0, Long.class);
+                    return !existMemberId1.equals(id) && !existMemberId2.equals(id);
+                });
+    }
+
+    @Test
+    @DisplayName("Refresh token 을 통해 사용자를 식별할 수 있다.")
+    void getMemberIdFromRt() {
+        Long result = tokenAuthService.getMemberIdFromRt(validRT);
+
+        assertThat(result).isEqualTo(existMemberId1);
+    }
+
+    @Test
+    @DisplayName("Access token 을 통해 사용자를 식별할 수 있다.")
+    void getMemberIdFromAt() {
+        Long result = tokenAuthService.getMemberIdFromAt(validAT);
+
+        assertThat(result).isEqualTo(existMemberId1);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰은 에러를 발생시킨다.")
+    void invalidTokenTest() {
+        assertThatThrownBy(() -> tokenAuthService.getMemberIdFromRt(invalidToken))
+                .isInstanceOf(InvalidTokenException.class);
+
+        assertThatThrownBy(() -> tokenAuthService.getMemberIdFromAt(invalidToken))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    @DisplayName("토큰이 유효하더라도 사용자가 식별되지 않으면 에러를 발생시킨다.")
+    void memberNotExistsTest() {
+        assertThatThrownBy(() -> tokenAuthService.getMemberIdFromRt(invalidMemberIdRt))
+                .isInstanceOf(NotFound.class);
+
+        assertThatThrownBy(() -> tokenAuthService.getMemberIdFromAt(invalidMemberIdAt))
+                .isInstanceOf(NotFound.class);
+    }
+
+    @Test
+    @DisplayName("저장되지 않은 RT 는 에러를 발생시킨다.")
+    void notRegisteredRefreshTokenTest() {
+        assertThatThrownBy(() -> tokenAuthService.getMemberIdFromRt(validRtButNotRegistered))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+}

--- a/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
+++ b/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
@@ -1,0 +1,73 @@
+package org.leisureup.member.internal.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.extern.slf4j.*;
+import org.junit.jupiter.api.*;
+import org.leisureup.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.member.internal.domain.*;
+import org.leisureup.member.internal.dto.request.*;
+import org.leisureup.member.internal.dto.request.SaveInterestRequest.*;
+import org.leisureup.member.internal.repository.*;
+import org.springframework.beans.factory.annotation.*;
+
+@Slf4j
+class MemberServiceTest extends IntegrationTestSupport {
+
+    private static final Long invalidMemberId = Long.MAX_VALUE;
+    private static Long testMemberId;
+    @Autowired
+    MemberService service;
+    @Autowired
+    MemberRepository memberRepo;
+    @Autowired
+    InterestRepository interestRepo;
+
+    private static SaveInterestRequest genReq(int ageRange) {
+        return new SaveInterestRequest(
+                ageRange, ReqWith.alone, ReqExperience.first,
+                ReqType.relieving, ReqLeisureType.any, ReqPreferredSeason.any,
+                ReqDifficulty.low
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        testMemberId = memberRepo.save(
+                Member.of("test", "test")
+        ).getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        interestRepo.deleteAll();
+        memberRepo.deleteAll();
+    }
+
+    @Test
+    @DisplayName("니즈 수집 질문을 저장한다.")
+    void saveInterest() {
+
+        var req = genReq(10);
+
+        service.saveInterest(testMemberId, req);
+
+        // 정보가 정상적으로 저장된다.
+        assertThat(interestRepo.findById(testMemberId))
+                .isPresent().get()
+                .hasNoNullFieldsOrProperties();
+    }
+
+    @Test
+    @DisplayName("멤버가 존재하지 않으면 에러가 발생한다.")
+    void memberNotFound() {
+
+        var req = genReq(20);
+
+        assertThatThrownBy(() -> service.getMember(invalidMemberId))
+                .isInstanceOf(NotFound.class);
+        assertThatThrownBy(() -> service.saveInterest(invalidMemberId, req))
+                .isInstanceOf(NotFound.class);
+    }
+}

--- a/src/test/java/org/leisureup/member/spi/MemberSpiTest.java
+++ b/src/test/java/org/leisureup/member/spi/MemberSpiTest.java
@@ -1,0 +1,96 @@
+package org.leisureup.member.spi;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.util.stream.*;
+import lombok.extern.slf4j.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.leisureup.*;
+import org.leisureup.member.internal.repository.*;
+import org.mockito.invocation.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.test.context.bean.override.mockito.*;
+
+@Slf4j
+class MemberSpiTest extends IntegrationTestSupport {
+
+    private static final Long memberId = 1L;
+    private static final Long validKakaoId = 1L,
+            validGoogleId = 2L,
+            validAppleId = 3L;
+    private static final Long invalidKakaoId = 4L,
+            invalidGoogleId = 5L,
+            invalidAppleId = 6L;
+    @Autowired
+    MemberSpi memberSpi;
+    @MockitoBean
+    AppleOAuthRepository appleOAuthRepo;
+    @MockitoBean
+    GoogleOAuthRepository googleOAuthRepo;
+    @MockitoBean
+    KakaoOAuthRepository kakaoOAuthRepo;
+
+    private static Stream<Arguments> validSocialArgs() {
+        return Stream.of(
+                Arguments.of(SocialType.KAKAO, validKakaoId),
+                Arguments.of(SocialType.GOOGLE, validGoogleId),
+                Arguments.of(SocialType.APPLE, validAppleId)
+        );
+    }
+
+    private static Stream<Arguments> invalidSocialArgs() {
+        return Stream.of(
+                Arguments.of(SocialType.KAKAO, invalidKakaoId),
+                Arguments.of(SocialType.GOOGLE, invalidGoogleId),
+                Arguments.of(SocialType.APPLE, invalidAppleId)
+        );
+    }
+
+    private static Optional<Long> setupMockAnswer(
+            Long validId, InvocationOnMock invocation
+    ) {
+        Long id = invocation.getArgument(0, Long.class);
+        Long result = validId.equals(id) ? memberId : null;
+        return Optional.ofNullable(result);
+    }
+
+    @BeforeEach
+    void setUp() {
+        when(kakaoOAuthRepo.findMemberIdBySocial(anyLong()))
+                .thenAnswer(invocation ->
+                        setupMockAnswer(validKakaoId, invocation));
+
+        when(googleOAuthRepo.findMemberIdBySocial(anyLong()))
+                .thenAnswer(invocation ->
+                        setupMockAnswer(validGoogleId, invocation));
+
+        when(appleOAuthRepo.findMemberIdBySocial(anyLong()))
+                .thenAnswer(invocation ->
+                        setupMockAnswer(validAppleId, invocation));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validSocialArgs")
+    @DisplayName("등록된 유저는 소셜인증 타입과 번호에 따라 번호를 식별할 수 있다.")
+    void getMemberId(SocialType type, Long socialId) {
+
+        Optional<Long> id = memberSpi.getMemberIdWithSocial(type, socialId);
+
+        assertThat(id).isNotEmpty().get()
+                .isEqualTo(memberId);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidSocialArgs")
+    @DisplayName("등록되지 않은 유저는 번호를 식별할 수 없다.")
+    void cannotGetMemberId(SocialType type, Long socialId) {
+
+        Optional<Long> id = memberSpi.getMemberIdWithSocial(type, socialId);
+
+        assertThat(id).isEmpty();
+    }
+}

--- a/src/test/java/org/leisureup/member/spi/MemberSpiTest.java
+++ b/src/test/java/org/leisureup/member/spi/MemberSpiTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
 import org.leisureup.*;
+import org.leisureup.member.internal.domain.*;
 import org.leisureup.member.internal.repository.*;
 import org.mockito.invocation.*;
 import org.springframework.beans.factory.annotation.*;
@@ -27,6 +28,8 @@ class MemberSpiTest extends IntegrationTestSupport {
             invalidAppleId = 6L;
     @Autowired
     MemberSpi memberSpi;
+    @Autowired
+    MemberRepository memberRepo;
     @MockitoBean
     AppleOAuthRepository appleOAuthRepo;
     @MockitoBean
@@ -43,6 +46,14 @@ class MemberSpiTest extends IntegrationTestSupport {
     }
 
     private static Stream<Arguments> invalidSocialArgs() {
+        return Stream.of(
+                Arguments.of(SocialType.KAKAO, invalidKakaoId),
+                Arguments.of(SocialType.GOOGLE, invalidGoogleId),
+                Arguments.of(SocialType.APPLE, invalidAppleId)
+        );
+    }
+
+    private static Stream<Arguments> createNewMemberArgs() {
         return Stream.of(
                 Arguments.of(SocialType.KAKAO, invalidKakaoId),
                 Arguments.of(SocialType.GOOGLE, invalidGoogleId),
@@ -92,5 +103,27 @@ class MemberSpiTest extends IntegrationTestSupport {
         Optional<Long> id = memberSpi.getMemberIdWithSocial(type, socialId);
 
         assertThat(id).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("createNewMemberArgs")
+    @DisplayName("소셜 인증 타입에 따라 새로운 사용자를 생성할 수 있다.")
+    void createNewMember(SocialType type, Long socialId) {
+
+        String name = "test", email = "test@email";
+        Long id = memberSpi.saveNewMember(type, socialId, name, email);
+
+        Optional<Member> find = memberRepo.findById(id);
+
+        assertThat(id).isNotNull();
+        assertThat(find).isPresent();
+
+        var member = find.get();
+        assertThat(member).satisfies(
+                m -> assertThat(m.getId()).isEqualTo(id),
+                m -> assertThat(m.getNickname()).isEqualTo(name),
+                m -> assertThat(m.getEmail()).isEqualTo(email)
+        );
+
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -2,8 +2,11 @@ spring:
   application.name: LeisureUp-BE
   threads.virtual.enabled: true
 
-  profiles.include:
-    - common-test-secret
+  profiles:
+    default: test
+    group:
+      test:
+        - common-test-secret
 
   datasource:
     url: jdbc:h2:mem:test
@@ -26,3 +29,4 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
+    org.springframework.transaction: trace

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,6 +15,7 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+        globally_quoted_identifiers: true
 
   data:
     redis:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

1. Jwt, OAuth 관련 component 들을 구성했습니다.
   - Jwt 관련 component 들을 모두 구현 완료되었습니다.
   - OAuth 실제 구현체는 이후 작업할 예정입니다. `(AppleOAuthClient.java, GoogleOAuthClient.java 등)`

2. 사용자 로그인, 회원가입, 토큰 발급에 해당하는 controller 를 구성하였습니다.
3. 요청 헤더의 Jwt 를 파싱, 사용자 ID 를 제공하는 기능을 추가하였습니다.

<details><summary> 사용자 ID 가져오는 법</summary>

`@JwtAuthRequired`, `@JwtAuthIfPossible` 어노테이션과 `AuthHolder` 를 통해 사용할 수 있습니다.

```java
package org.leisureup;

import lombok.*;
import org.leisureup.global.*;
import org.leisureup.global.response.*;
import org.springframework.context.annotation.*;
import org.springframework.web.bind.annotation.*;

@Profile("test")
@RestController
@RequiredArgsConstructor
@RequestMapping("/test")
public class JwtAuthTestController {

    // Jwt 인가 테스트용 controller

    private final AuthHolder authHolder;

    @JwtAuthRequired
    @GetMapping("/auth-required")
    public ApiResponse<Long> getMemberIdFromJwt() {
        Long id = authHolder.getMemberId();
        return ApiResponse.success(200, id);
    }

    @JwtAuthIfPossible
    @GetMapping("/auth-bypassable")
    public ApiResponse<Long> getMemberFromJwt() {
        Long id = authHolder.getMemberId();
        return ApiResponse.success(200, id);
    }
}
```

`@JwtAuthRequired`, `@JwtAuthIfPossible` 모두 헤더의 Jwt 를 파싱, `AuthHolder` 에 사용자 ID 를 저장합니다.

이 때 `@JwtAuthIfPossible` 는 실패시 아무런 동작을 하지 않지만 `@JwtAuthRequired` 는 `UnauthenticatedException` 을 발생시킵니다.

이 후 `AuthHolder.getMemberId()` 메서드를 통해 사용자 ID 를 가져올 수 있습니다.

</details>

## 💬 리뷰 요구사항 (선택)

다른 도메인과 연관된 부분은 `@JwtAuthRequired`, `@JwtAuthIfPossible`, `AuthHolder` 정도라 
나머지 부분은 가볍게 보시면 좋을 것 같습니다.

+) `feat/member` 브랜치에서 rebase 한 후 작업해 #10 의 작업물이 섞여있습니다. #10 merge 후 검토하시면 더 좋을 것 같습니다.
