### PR TITLE
Feat/location - TourApi 를 통해 장소 조회하는 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.springframework.modulith:spring-modulith-starter-test'
+    testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-stub-runner:4.3.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/leisureup/global/exception/TourApiException.java
+++ b/src/main/java/org/leisureup/global/exception/TourApiException.java
@@ -1,0 +1,8 @@
+package org.leisureup.global.exception;
+
+public class TourApiException extends CustomException {
+
+    public TourApiException(String message) {
+        super(502, message);
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/LocationDescription.java
+++ b/src/main/java/org/leisureup/location/internal/domain/LocationDescription.java
@@ -31,7 +31,7 @@ public class LocationDescription {
      * @warning {@code TourApi} 에서 해당 정보는 {@code <a href="...">} 와 같은 태그로 제공됨. 그래서 파싱 제대로 안하면 이상할수도
      * 있음.
      */
-    @Column(length = 100)
+    @Lob
     private String homepageInfo;
 
     @Column(length = 30)

--- a/src/main/java/org/leisureup/location/internal/dto/api/ApiResponse.java
+++ b/src/main/java/org/leisureup/location/internal/dto/api/ApiResponse.java
@@ -1,0 +1,17 @@
+package org.leisureup.location.internal.dto.api;
+
+import java.util.*;
+
+/**
+ * 외부 API 호출과 관련된 계약
+ */
+public interface ApiResponse<I> {
+
+    boolean isSuccess();
+
+    boolean isEmpty();
+
+    I getSingleItem();
+
+    List<I> getAllItems();
+}

--- a/src/main/java/org/leisureup/location/internal/dto/api/CommonInfo.java
+++ b/src/main/java/org/leisureup/location/internal/dto/api/CommonInfo.java
@@ -1,0 +1,54 @@
+package org.leisureup.location.internal.dto.api;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.*;
+import com.fasterxml.jackson.databind.annotation.*;
+import java.time.*;
+import org.leisureup.location.internal.domain.*;
+import org.leisureup.location.internal.service.*;
+
+/**
+ * 공통정보 응답 class
+ *
+ * @see GetCommonInfoResponse
+ * @see TourApiClient#getCommonInfo
+ */
+@JsonNaming(LowerCaseStrategy.class)
+public record CommonInfo(
+        Long contentId,
+        Long contentTypeId,
+        String title,
+        @JsonFormat(pattern = "yyyyMMddHHmmss") LocalDateTime createdTime,
+        @JsonFormat(pattern = "yyyyMMddHHmmss") LocalDateTime modifiedTime,
+        String tel,
+        String telName,
+        String homepage,
+        String firstImage,
+        String firstImage2,
+        String cat1,
+        String cat2,
+        String cat3,
+        String addr1,
+        String addr2,
+        String zipcode,
+        Double mapX,
+        Double mapY,
+        String overview
+) {
+
+    public GpsCord gpsCord() {
+        return GpsCord.of(mapX, mapY);
+    }
+
+    public Address address() {
+        return Address.of(
+                addr1, addr2, zipcode
+        );
+    }
+
+    public LocationDescription locationDescription() {
+        return LocationDescription.of(
+                overview, homepage, tel, firstImage, firstImage2
+        );
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/dto/api/GetCommonInfoResponse.java
+++ b/src/main/java/org/leisureup/location/internal/dto/api/GetCommonInfoResponse.java
@@ -1,0 +1,15 @@
+package org.leisureup.location.internal.dto.api;
+
+import lombok.*;
+import org.leisureup.location.internal.service.*;
+
+/**
+ * 공통정보 응답을 위한 class
+ *
+ * @see CommonInfo
+ * @see TourApiClient#getCommonInfo
+ */
+@NoArgsConstructor
+public class GetCommonInfoResponse extends TourApiResponse<CommonInfo> {
+
+}

--- a/src/main/java/org/leisureup/location/internal/dto/api/TourApiResponse.java
+++ b/src/main/java/org/leisureup/location/internal/dto/api/TourApiResponse.java
@@ -1,0 +1,71 @@
+package org.leisureup.location.internal.dto.api;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.location.internal.dto.api.internal.*;
+
+/**
+ * TourApi 응답 명시를 위한 추상 클래스
+ *
+ * @param <I> TourApi 응답의 {@code item} 속성 클래스
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class TourApiResponse<I> implements ApiResponse<I> {
+
+    @Getter     // Getter 없으면 response null 로 설정되던데 왜그런거지...?
+    private Response<I> response;
+
+    public final String getMessage() {
+        String msg = "";
+        try {
+            msg = response.header().resultMsg();
+        } catch (Exception ignored) {
+            // ignored
+        }
+
+        return msg;
+    }
+
+    @Override
+    public final boolean isSuccess() {
+        return response != null && response.isSuccess();
+    }
+
+    @Override
+    public final boolean isEmpty() {
+
+        if (this.isSuccess()) {
+            assert response != null;
+            Body<I> body = response.body();
+            return body == null || body.isEmpty();
+        }
+
+        return true;
+    }
+
+    @Override
+    public final I getSingleItem() {
+
+        if (!this.isSuccess()) {
+            throw new IllegalStateException("Response is not successful");
+        }
+
+        Body<I> body = response.body();
+        assert body != null;
+
+        return body.getSingleItem();
+    }
+
+    @Override
+    public final List<I> getAllItems() {
+        if (!this.isSuccess()) {
+            throw new IllegalStateException("Response is not successful");
+        }
+
+        Body<I> body = response.body();
+        assert body != null;
+
+        return body.getAllItems();
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/dto/api/internal/Body.java
+++ b/src/main/java/org/leisureup/location/internal/dto/api/internal/Body.java
@@ -1,0 +1,38 @@
+package org.leisureup.location.internal.dto.api.internal;
+
+import java.util.*;
+
+public record Body<I>(
+        int numOfRows,
+        int pageNo,
+        int totalCount,
+        Items<I> items
+) {
+
+    public boolean isEmpty() {
+        return numOfRows == 0 || items == null || items.item().isEmpty();
+    }
+
+    public I getSingleItem() {
+        if (this.isEmpty()) {
+            throw new IllegalStateException("No item found");
+        }
+
+        List<I> itemList = items.item();
+
+        if (itemList.size() != 1) {
+            throw new IllegalStateException("Multiple items found");
+        }
+
+        return itemList.getFirst();
+    }
+
+    public List<I> getAllItems() {
+        if (this.isEmpty()) {
+            throw new IllegalStateException("No items found");
+        }
+
+        return items.item();
+    }
+
+}

--- a/src/main/java/org/leisureup/location/internal/dto/api/internal/Header.java
+++ b/src/main/java/org/leisureup/location/internal/dto/api/internal/Header.java
@@ -1,0 +1,14 @@
+package org.leisureup.location.internal.dto.api.internal;
+
+public record Header(
+        String resultCode,
+        String resultMsg
+) {
+
+    private static final String SUCCESS_CODE = "0000";
+    private static final String SUCCESS_MSG = "OK";
+
+    public boolean isSuccess() {
+        return SUCCESS_CODE.equals(resultCode) && SUCCESS_MSG.equals(resultMsg);
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/dto/api/internal/Items.java
+++ b/src/main/java/org/leisureup/location/internal/dto/api/internal/Items.java
@@ -1,0 +1,13 @@
+package org.leisureup.location.internal.dto.api.internal;
+
+import com.fasterxml.jackson.databind.annotation.*;
+import java.util.*;
+
+// Generic 자체는 문제 없는데, 요청 관련 정보 없으면 API 응답이 {"items" : ""} 처럼 제공되서
+// custom deserializer 가 필요함.
+@JsonDeserialize(using = ItemsDeserializer.class)
+public record Items<I>(
+        List<I> item
+) {
+
+}

--- a/src/main/java/org/leisureup/location/internal/dto/api/internal/ItemsDeserializer.java
+++ b/src/main/java/org/leisureup/location/internal/dto/api/internal/ItemsDeserializer.java
@@ -1,0 +1,60 @@
+package org.leisureup.location.internal.dto.api.internal;
+
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.*;
+import java.io.*;
+import java.util.*;
+
+// 아니 이게 왜 되는거지..... 진짜 모르겠다.. ㅠㅠㅠㅠㅠㅠ
+// 참고 : https://stackoverflow.com/questions/36159677/how-to-create-a-custom-deserializer-in-jackson-for-a-generic-type
+public class ItemsDeserializer<I>
+        extends JsonDeserializer<Items<I>> implements ContextualDeserializer {
+
+    private JavaType genericItemType;
+
+    @Override
+    public Items<I> deserialize(JsonParser p, DeserializationContext context)
+            throws IOException, JacksonException {
+
+        JsonNode itemsNode = p.getCodec().readTree(p);
+
+        // 만약 {"items" : ""} 가 들어오거나 존재하지 않으면 빈 items 를 반환한다.
+        if (itemsNode == null || (itemsNode.isTextual() && itemsNode.asText().isBlank())) {
+            return new Items<>(Collections.emptyList());
+        }
+
+        // 만약 {"items" : {"item" : []}} 가 들어오거나 존재하지 않으면 빈 items 를 반환한다.
+        JsonNode itemNode = itemsNode.get("item");
+        if (itemNode == null || itemNode.isNull() || itemNode.isEmpty()) {
+            return new Items<>(Collections.emptyList());
+        }
+
+        // 여기 이후로는 도대체 뭘 하는건지 잘 모르겠다... ㅠ
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+        JavaType listType = mapper.getTypeFactory()
+                .constructCollectionType(List.class, genericItemType);
+        List<I> items;
+
+        if (itemNode.isArray()) {
+            items = mapper.readerFor(listType).readValue(itemNode);
+        } else {
+            // Single object case
+            I singleItem = mapper.readerFor(genericItemType).readValue(itemNode);
+            items = List.of(singleItem);
+        }
+
+        return new Items<>(items);
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(
+            DeserializationContext context, BeanProperty property
+    ) throws JsonMappingException {
+        JavaType wrapperType = property.getType(); // Items<I>
+        JavaType genericItemType = wrapperType.containedType(0); // I
+        ItemsDeserializer<?> objectItemsDeserializer = new ItemsDeserializer<>();
+        objectItemsDeserializer.genericItemType = genericItemType;
+        return objectItemsDeserializer;
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/dto/api/internal/Response.java
+++ b/src/main/java/org/leisureup/location/internal/dto/api/internal/Response.java
@@ -1,0 +1,62 @@
+
+package org.leisureup.location.internal.dto.api.internal;
+
+/**
+ * TourApi 응답은 대게 다음 모양처럼 구성됨
+ *
+ * <pre>
+ *     {@code
+ *      {
+ *          "response": {
+ *              "header": {
+ *                  "resultCode": "0000",
+ *                  "resultMsg": "OK"
+ *              },
+ *              "body": {
+ *                  "items": {
+ *                      "item": [
+ *                          { ... },
+ *                          { ... }
+ *                      ]
+ *                  },
+ *                  "numOfRows": 2,
+ *                  "pageNo": 1,
+ *                  "totalCount": 2
+ *              }
+ *          }
+ *      }
+ *     }
+ * </pre>
+ * <p>
+ * 만약 요청에 대한 정보 없으면 아래처럼 구성됨
+ *
+ * <pre>
+ *     {@code
+ *      {
+ *          "response": {
+ *              "header": {
+ *                  "resultCode": "0000",
+ *                  "resultMsg": "OK"
+ *              },
+ *              "body": {
+ *                  "items": "",
+ *                  "numOfRows": 0,
+ *                  "pageNo": 1,
+ *                  "totalCount": 0
+ *              }
+ *          }
+ *      }
+ *     }
+ * </pre>
+ */
+public record Response<I>(
+        Header header,
+        Body<I> body
+) {
+
+    public boolean isSuccess() {
+        return header != null && body != null && header.isSuccess();
+    }
+}
+
+

--- a/src/main/java/org/leisureup/location/internal/dto/response/GetLocationResponse.java
+++ b/src/main/java/org/leisureup/location/internal/dto/response/GetLocationResponse.java
@@ -15,4 +15,25 @@ public record GetLocationResponse(
     public enum Category {
         EARTH, WATER, SKY, OTHER
     }
+
+    public static GetLocationResponse of(
+            Long id, String name, double gpsX, double gpsY,
+            String add1, String add2, String zipcode,
+            String intro, String homepage, String tel,
+            String thumb1, String thumb2,
+            String categoryType
+    ) {
+
+        Category cat = switch (categoryType) {
+            case "EARTH" -> Category.EARTH;
+            case "WATER" -> Category.WATER;
+            case "SKY" -> Category.SKY;
+            default -> Category.OTHER;
+        };
+
+        return new GetLocationResponse(
+                id, name, gpsX, gpsY, add1, add2, zipcode,
+                intro, homepage, tel, thumb1, thumb2, cat
+        );
+    }
 }

--- a/src/main/java/org/leisureup/location/internal/repository/CategoryRepository.java
+++ b/src/main/java/org/leisureup/location/internal/repository/CategoryRepository.java
@@ -1,8 +1,10 @@
 package org.leisureup.location.internal.repository;
 
+import java.util.*;
 import org.leisureup.location.internal.domain.*;
 import org.springframework.data.jpa.repository.*;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
+    Optional<Category> findByCategoryCode(String categoryCode);
 }

--- a/src/main/java/org/leisureup/location/internal/repository/LocationRepository.java
+++ b/src/main/java/org/leisureup/location/internal/repository/LocationRepository.java
@@ -1,8 +1,15 @@
 package org.leisureup.location.internal.repository;
 
+import java.util.*;
 import org.leisureup.location.internal.domain.*;
 import org.springframework.data.jpa.repository.*;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
 
+    @Query("""
+            select l from Location l
+            right join fetch l.locationCategory
+            where l.id = :id
+            """)
+    Optional<Location> findByIdFetchingCategory(Long id);
 }

--- a/src/main/java/org/leisureup/location/internal/service/LocationFetchService.java
+++ b/src/main/java/org/leisureup/location/internal/service/LocationFetchService.java
@@ -2,8 +2,8 @@ package org.leisureup.location.internal.service;
 
 import lombok.*;
 import lombok.extern.slf4j.*;
-import org.leisureup.global.exception.*;
-import org.leisureup.location.internal.dto.response.*;
+import org.leisureup.location.internal.domain.*;
+import org.leisureup.location.internal.dto.api.*;
 import org.leisureup.location.internal.repository.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
@@ -13,7 +13,23 @@ import org.springframework.transaction.annotation.*;
 @RequiredArgsConstructor
 public class LocationFetchService {
 
+    private final TourApiService tourApiService;
     private final LocationRepository locationRepo;
+    private final CategoryRepository categoryRepo;
+
+    private static Location buildEntityFromInfo(CommonInfo info) {
+
+        GpsCord cord = info.gpsCord();
+        Address address = info.address();
+        LocationDescription desc = info.locationDescription();
+
+        Location loc = Location.of(
+                info.contentId(), info.title(), cord, address, desc
+        );
+        loc.synchronizeTo(info.modifiedTime());
+
+        return loc;
+    }
 
     /**
      * {@code locationId} 에 해당하는 장소를 가져오고 DB 에 저장한다.
@@ -21,11 +37,27 @@ public class LocationFetchService {
      * @param locationId 장소 id
      */
     @Transactional
-    public GetLocationResponse fetchAndStoreLocation(Long locationId) {
-        // TODO : 완성하기
-        // TourApi 에 해당 장소가 없으면 not found
-        // TourApi 응답을 받지 못하거나 에러가 발생했으면 internal server error
-        // 그 외 성공적으로 가져오면 DB 에 정보 저장 필요
-        throw new NotImplemented();
+    public Location fetchAndStoreLocation(Long locationId) {
+
+        // api 로 정보를 가져온다. 실패하면 메서드에서 에러가 발생한다.
+        CommonInfo fetchedInfo = tourApiService.getCommonInfo(locationId);
+
+        String categoryCode = fetchedInfo.cat3();
+        Category cat = categoryRepo.findByCategoryCode(categoryCode)
+                .orElse(null);
+
+        // 등록되지 않은 카테고리면 ETC 카테고리 생성
+        if (cat == null) {
+            // TODO : 카테고리 이름은 임시로 작성. 나중에 바꿀 수 있지만 api 호출 1 번 더 필요
+            cat = categoryRepo.save(
+                    CatOther.of(fetchedInfo.cat2(), categoryCode)
+            );
+        }
+
+        // 정보를 통해 장소를 DB 에 저장한다. 카테고리도 지정해둔다.
+        Location loc = buildEntityFromInfo(fetchedInfo);
+        loc.changeCategory(cat);
+
+        return locationRepo.save(loc);
     }
 }

--- a/src/main/java/org/leisureup/location/internal/service/LocationService.java
+++ b/src/main/java/org/leisureup/location/internal/service/LocationService.java
@@ -1,8 +1,6 @@
 package org.leisureup.location.internal.service;
 
-import java.util.*;
 import lombok.*;
-import org.leisureup.global.exception.*;
 import org.leisureup.location.internal.domain.*;
 import org.leisureup.location.internal.dto.response.*;
 import org.leisureup.location.internal.repository.*;
@@ -22,17 +20,54 @@ public class LocationService {
      */
     public GetLocationResponse getLocation(Long locationId) {
 
-        Optional<Location> optional = locationRepo.findById(locationId);
+        Location location = locationRepo.findByIdFetchingCategory(locationId)
+                .orElse(null);
 
-        if (optional.isPresent()) {
-            return buildResponse(optional.get());
-        }
+        return Utils.buildResponse(
+                location != null ?
+                        location :
+                        fetchService.fetchAndStoreLocation(locationId)
+        );
+    }
+}
 
-        return fetchService.fetchAndStoreLocation(locationId);
+class Utils {
+
+    static String emptyIfNull(String s) {
+        return s != null ? s : "";
     }
 
-    private GetLocationResponse buildResponse(Location location) {
-        // TODO: 완성하기
-        throw new NotImplemented();
+    static GetLocationResponse buildResponse(Location location) {
+        Long id = location.getId();
+        String name = location.getTitle();
+        GpsCord cord = location.getGpsCord();       // 반드시 null 아님.
+        double gpsX = cord.getGpsX(), gpxY = cord.getGpsY();
+
+        Address address = location.getAddress();    // nullable
+        address = address != null ? address :
+                Address.of(null, null, null);
+        String add1 = address.getBriefedAddress();
+        String add2 = address.getDetailedAddress();
+        String zipcode = address.getZipcode();
+
+        LocationDescription desc = location.getDescription();   // nullable
+        desc = desc != null ? desc :
+                LocationDescription.of(null, null, null, null, null);
+        String intro = desc.getOverview();
+        String homepage = desc.getHomepageInfo();
+        String tel = desc.getTelephoneNumber();
+        String thumb1 = desc.getLargeThumbnailUrl();
+        String thumb2 = desc.getLargeThumbnailUrl();
+
+        Category cat = location.getLocationCategory();
+        String catType = cat.getCategoryType();
+
+        return GetLocationResponse.of(
+                id, name, gpsX, gpxY,
+                emptyIfNull(add1), emptyIfNull(add2), emptyIfNull(zipcode),
+                emptyIfNull(intro), emptyIfNull(homepage), emptyIfNull(tel),
+                emptyIfNull(thumb1), emptyIfNull(thumb2),
+                catType
+        );
     }
 }

--- a/src/main/java/org/leisureup/location/internal/service/TourApiClient.java
+++ b/src/main/java/org/leisureup/location/internal/service/TourApiClient.java
@@ -1,0 +1,24 @@
+package org.leisureup.location.internal.service;
+
+import org.leisureup.location.internal.dto.api.*;
+import org.springframework.cloud.openfeign.*;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * TourApi 에 API 요청하는 client
+ */
+@FeignClient(
+        name = "tourApiClient",
+        url = "${feign.tour-api.url}"
+)
+public interface TourApiClient {
+
+    @GetMapping("/detailCommon2")
+    GetCommonInfoResponse getCommonInfo(
+            @RequestParam("contentId") Long contentId,
+            @RequestParam("serviceKey") String key,
+            @RequestParam(value = "MobileApp") String app,
+            @RequestParam(value = "MobileOS") String os,
+            @RequestParam(value = "_type") String type
+    );
+}

--- a/src/main/java/org/leisureup/location/internal/service/TourApiService.java
+++ b/src/main/java/org/leisureup/location/internal/service/TourApiService.java
@@ -1,0 +1,63 @@
+package org.leisureup.location.internal.service;
+
+import org.leisureup.global.exception.*;
+import org.leisureup.location.internal.dto.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
+
+@Service
+public class TourApiService {
+
+    private final TourApiClient apiClient;
+
+    private final String key, app, os;
+    private final String rspType;
+
+    public TourApiService(
+            TourApiClient apiClient,
+            @Value("${tourApi.key}") String apiKey,
+            @Value("${tourApi.types.app}") String appType,
+            @Value("${tourApi.types.os}") String osType,
+            @Value("${tourApi.types.response}") String responseType
+    ) {
+        this.apiClient = apiClient;
+        this.key = apiKey;
+        this.app = appType;
+        this.os = osType;
+        this.rspType = responseType;
+    }
+
+    private static TourApiException buildExMsg(TourApiResponse<?> response) {
+        String message = "API 통신 중 에러가 발생했습니다.";
+
+        try {
+            message += " : " + response.getMessage();
+        } catch (Exception ignored) {
+            // 응답 메시지까지 못받았으면 그냥 반환한다.
+        }
+
+        return new TourApiException(message);
+    }
+
+    /**
+     * {@code locationId} 에 해당하는 정보를 API 로 가져온다.
+     * <p>
+     * 정보 fetch 에 실패하면 {@link TourApiException} 을 발생하고, 정보가 존재하지 않으면 {@link NotFound} 를 발생시킨다.
+     */
+    public CommonInfo getCommonInfo(Long locationId) {
+
+        GetCommonInfoResponse rsp = apiClient.getCommonInfo(
+                locationId, key, app, os, rspType
+        );
+
+        if (rsp == null || !rsp.isSuccess()) {
+            throw buildExMsg(rsp);
+        }
+
+        if (rsp.isEmpty()) {
+            throw new NotFound("Not found");
+        }
+
+        return rsp.getSingleItem();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,6 +34,9 @@ spring:
       port: 6379
       password:
 
+  cloud.openfeign.client.config.default:
+    logger-level: full
+
 springdoc:
   cache.disabled: true
   api-docs.groups.enabled: true
@@ -53,6 +56,10 @@ springdoc:
   show-actuator: true
   show-login-endpoint: true
   paths-to-match: /**
+
+feign:
+  tour-api:
+    url: http://apis.data.go.kr/B551011/KorService2
 
 logging:
   level:

--- a/src/test/java/org/leisureup/location/internal/service/LocationServiceTest.java
+++ b/src/test/java/org/leisureup/location/internal/service/LocationServiceTest.java
@@ -1,0 +1,171 @@
+package org.leisureup.location.internal.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.github.tomakehurst.wiremock.*;
+import com.github.tomakehurst.wiremock.matching.*;
+import java.nio.file.*;
+import java.time.*;
+import java.util.*;
+import org.junit.jupiter.api.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.location.internal.domain.*;
+import org.leisureup.location.internal.dto.response.*;
+import org.leisureup.location.internal.repository.*;
+import org.mockito.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.cloud.contract.wiremock.*;
+import org.springframework.test.context.*;
+import org.springframework.test.context.bean.override.mockito.*;
+import org.springframework.util.*;
+
+@SpringBootTest
+@AutoConfigureWireMock(port = 0)
+@TestPropertySource(properties = {
+        "feign.tour-api.url=http://localhost:${wiremock.server.port}",
+        "tourApi.key=testing"
+})
+class LocationServiceTest {
+
+    private final static Long dbExistingLocationId = 10L;
+    private final static Long apiExistingLocationId = 990140L;
+    private final static Long apiNonExistentLocationId = 0L;
+
+    @Value("${tourApi.key}")
+    String apiKeyForTest;
+
+    @Value("${tourApi.types.os}")
+    String os;
+
+    @Value("${tourApi.types.app}")
+    String app;
+
+    @Value("${tourApi.types.response}")
+    String response;
+
+    @Autowired
+    WireMockServer wireMockServer;
+    @Autowired
+    LocationService locationService;
+    @Autowired
+    LocationRepository locationRepo;
+    @Autowired
+    CategoryRepository categoryRepo;
+    @MockitoSpyBean
+    LocationFetchService locationFetchService;
+
+
+    private static byte[] supplyResponse(Long locationId) {
+
+        String classPath = String.format(
+                "classpath:" +
+                "mock-server-response/tour-api/get-common-detail" +
+                "/%d.json", locationId
+        );
+
+        try {
+            return Files.readAllBytes(
+                    ResourceUtils.getFile(classPath).toPath()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    void stubMockServer(Long locationId) {
+
+        byte[] body = supplyResponse(locationId);
+
+        Map<String, StringValuePattern> queryParams = new HashMap<>();
+        queryParams.put("serviceKey", equalTo(apiKeyForTest));
+        queryParams.put("MobileApp", equalTo(app));
+        queryParams.put("MobileOS", equalTo(os));
+        queryParams.put("_type", equalTo(response));
+        queryParams.put("contentId", equalTo(String.valueOf(locationId)));
+
+        stubFor(
+                get(urlPathEqualTo("/detailCommon2"))
+                        .withQueryParams(queryParams)
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withBody(body)
+                                        .withHeader(
+                                                "Content-Type", "application/json"
+                                        )
+                        )
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer.start();
+
+        stubMockServer(apiExistingLocationId);
+        stubMockServer(apiNonExistentLocationId);
+
+        Category cat = CatOther.of("testing", "abcde");
+        categoryRepo.save(cat);
+
+        GpsCord cord = GpsCord.of(0.1234, 0.1234);
+        Location loc = Location.of(
+                dbExistingLocationId, "test", cord,
+                null, null
+        );
+        loc.changeCategory(cat);
+        loc.synchronizeTo(LocalDateTime.now());
+
+        locationRepo.save(loc);
+    }
+
+    @AfterEach
+    void tearDown() {
+        locationRepo.deleteAll();
+        categoryRepo.deleteAll();
+        wireMockServer.resetAll();
+        wireMockServer.stop();
+    }
+
+
+    @Test
+    @DisplayName("DB 에 장소가 없을땐 API 로 가져와 저장한다.")
+    void testGetLocation() {
+
+        GetLocationResponse resp = locationService.getLocation(apiExistingLocationId);
+
+        // 정상 응답이 돌아온다.
+        assertThat(resp).isNotNull().hasNoNullFieldsOrProperties();
+        assertThat(resp.id()).isEqualTo(apiExistingLocationId);
+
+        // db 에도 저장되어 있다.
+        assertThat(locationRepo.findById(apiExistingLocationId)).isPresent();
+
+    }
+
+    @Test
+    @DisplayName("API 에 장소가 없으면 NotFound 에러가 발생한다.")
+    void testNonExistingLocation() {
+
+        assertThatThrownBy(() -> locationService.getLocation(apiNonExistentLocationId))
+                .isInstanceOf(NotFound.class);
+
+    }
+
+    @Test
+    @DisplayName("DB 에 장소가 있을 땐 API 를 호출하지 않는다.")
+    void testDbExistingLocation() {
+        GetLocationResponse resp = locationService.getLocation(dbExistingLocationId);
+
+        // 정상 응답이 돌아온다.
+        assertThat(resp).isNotNull().hasNoNullFieldsOrProperties();
+        assertThat(resp.id()).isEqualTo(dbExistingLocationId);
+
+        // Api 외부 호출한 적이 없다.
+        Mockito.verify(locationFetchService, Mockito.times(0))
+                .fetchAndStoreLocation(dbExistingLocationId);
+
+    }
+
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -22,6 +22,10 @@ spring:
       port: 6379
       password:
 
+feign:
+  tour-api:
+    url: http://apis.data.go.kr/B551011/KorService2
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/test/resources/mock-server-response/tour-api/get-common-detail/0.json
+++ b/src/test/resources/mock-server-response/tour-api/get-common-detail/0.json
@@ -1,0 +1,14 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "0000",
+      "resultMsg": "OK"
+    },
+    "body": {
+      "items": "",
+      "numOfRows": 0,
+      "pageNo": 1,
+      "totalCount": 0
+    }
+  }
+}

--- a/src/test/resources/mock-server-response/tour-api/get-common-detail/990140.json
+++ b/src/test/resources/mock-server-response/tour-api/get-common-detail/990140.json
@@ -1,0 +1,47 @@
+{
+  "response": {
+    "header": {
+      "resultCode": "0000",
+      "resultMsg": "OK"
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "contentid": "990140",
+            "contenttypeid": "28",
+            "title": "장충체육관",
+            "createdtime": "20100331234809",
+            "modifiedtime": "20240522150419",
+            "tel": "",
+            "telname": "",
+            "homepage": "장충체육관 <a href=\"https://www.sisul.or.kr/open_content/jangchung/\" target=\"_blank\" title=\"새창 : 장충체육관 홈페이지로 이동\">https://www.sisul.or.kr</a>",
+            "firstimage": "http://tong.visitkorea.or.kr/cms/resource/06/3083906_image2_1.JPG",
+            "firstimage2": "http://tong.visitkorea.or.kr/cms/resource/06/3083906_image3_1.JPG",
+            "cpyrhtDivCd": "Type3",
+            "areacode": "1",
+            "sigungucode": "24",
+            "lDongRegnCd": "11",
+            "lDongSignguCd": "140",
+            "lclsSystm1": "VE",
+            "lclsSystm2": "VE10",
+            "lclsSystm3": "VE100100",
+            "cat1": "A03",
+            "cat2": "A0302",
+            "cat3": "A03020300",
+            "addr1": "서울특별시 중구 동호로 241",
+            "addr2": "",
+            "zipcode": "04605",
+            "mapx": "127.0068047884",
+            "mapy": "37.5582390522",
+            "mlevel": "6",
+            "overview": "서울 중구 장충동2가에 있는 장충체육관(奬忠體育館)은 한국에서 처음으로 세워진 실내 종합경기장으로 1963년 2월 1일에 개관하였다. 체육관에서는 국내/해외의 스포츠경기 외에도 국제경연대회 및 콘서트, 마당놀이 등의 문화공연 등 각종 행사가 펼쳐진다.\n체육관 외부는 원의 형태이고 돔으로된 지붕을 가지고 있다. 체육관 내부의 원형 코트는 배구, 농구, 핸드볼 경기가 가능하며, 코트를 중심으로 본부석 및 하단 가변 관람석과 상단 관람석이 위치해서 중앙으로 시선을 집중시키며, 각 관람석의 위치에 따른 시각적 사각지대를 만들지 않는다."
+          }
+        ]
+      },
+      "numOfRows": 1,
+      "pageNo": 1,
+      "totalCount": 1
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

1. TourApi `[공통정보조회]` 를 통해 정보 조회, DB 에 저장하는 기능을 추가했습니다.
   - `{id}` 에 해당하는 장소가 DB 에 없으면 API 를 사용합니다.
       - API 를 통해 장소를 식별하면 DB 에 저장합니다.
       - API 를 통해 장소가 식별되지 않으면 `NotFound` 에러를 발생시킵니다.
   - `{id}` 에 해당하는 장소가 DB 에 존재하면 API 를 사용하지 않습니다.

2. `/locations/{id}` endpoint 구현을 완료하였습니다.
3. `WireMock` 관련 종속을 추가해 테스트 코드를 구성하였습니다.

## 💬 리뷰 요구사항 (선택)

기능 구현 중 제너릭 타입 속성을 Jackson deserialize 하는데 난관을 겪었습니다.

- 관련 class : `ItemsDeserializer`, `Items`

검색을 통해 해결하긴 했지만 정확히 어떤 과정이 일어나는지, 어떻게 해결되는지 잘 이해하지 못했습니다.

- [How to create a custom deserializer in Jackson for a generic type?](https://stackoverflow.com/questions/36159677/how-to-create-a-custom-deserializer-in-jackson-for-a-generic-type)

그래서 시간 여유가 있으시다면 `ItemsDeserializer` 에 대해 재검토해주시면 감사하겠습니다.

+) `application-test-common-secret.yaml`, `application-common-secret.yaml` 에 TourApi 관련 속성을 추가했습니다.
