### PR TITLE
Fix/social - 소셜 인증 관련 식별자 type 변경

### DIFF
--- a/src/main/java/org/leisureup/global/auth/social/OAuthResponse.java
+++ b/src/main/java/org/leisureup/global/auth/social/OAuthResponse.java
@@ -1,12 +1,12 @@
 package org.leisureup.global.auth.social;
 
 public record OAuthResponse(
-        Long socialId,
+        String socialId,
         String name,
         String email
 ) {
 
-    public static OAuthResponse of(Long socialId, String name, String email) {
+    public static OAuthResponse of(String socialId, String name, String email) {
         return new OAuthResponse(socialId, name, email);
     }
 }

--- a/src/main/java/org/leisureup/global/auth/social/SocialAuthService.java
+++ b/src/main/java/org/leisureup/global/auth/social/SocialAuthService.java
@@ -50,7 +50,7 @@ public class SocialAuthService {
         AuthType authType = req.authType();
         OAuthResponse oauthResponse = oauthClients.get(authType)
                 .fetchInfo(req.token());
-        Long socialId = oauthResponse.socialId();
+        String socialId = oauthResponse.socialId();
 
         // 사용자가 가입되어 있는지 아닌지 확인한다.
         SocialType socialType = getType(authType);

--- a/src/main/java/org/leisureup/member/internal/domain/AppleOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/AppleOAuth.java
@@ -13,13 +13,13 @@ import lombok.*;
 public class AppleOAuth extends BaseTimeEntity {
 
     @Id
-    private Long id;
+    private String id;
 
     @OneToOne(optional = false)
     @JoinColumn(name = "member_id", nullable = false, updatable = false)
     private Member member;
 
-    public static AppleOAuth of(Long socialId, Member member) {
+    public static AppleOAuth of(String socialId, Member member) {
         return new AppleOAuth(socialId, member);
     }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/GoogleOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/GoogleOAuth.java
@@ -13,13 +13,13 @@ import lombok.*;
 public class GoogleOAuth extends BaseTimeEntity {
 
     @Id
-    private Long id;
+    private String id;
 
     @OneToOne(optional = false)
     @JoinColumn(name = "member_id", nullable = false, updatable = false)
     private Member member;
 
-    public static GoogleOAuth of(Long socialId, Member member) {
+    public static GoogleOAuth of(String socialId, Member member) {
         return new GoogleOAuth(socialId, member);
     }
 }

--- a/src/main/java/org/leisureup/member/internal/domain/KakaoOAuth.java
+++ b/src/main/java/org/leisureup/member/internal/domain/KakaoOAuth.java
@@ -13,13 +13,13 @@ import lombok.*;
 public class KakaoOAuth extends BaseTimeEntity {
 
     @Id
-    private Long id;
+    private String id;
 
     @OneToOne(optional = false)
     @JoinColumn(name = "member_id", nullable = false, updatable = false)
     private Member member;
 
-    public static KakaoOAuth of(Long socialId, Member member) {
+    public static KakaoOAuth of(String socialId, Member member) {
         return new KakaoOAuth(socialId, member);
     }
 }

--- a/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
@@ -12,5 +12,5 @@ public interface AppleOAuthRepository
             right join ao.member m
             where ao.id = :socialId
             """)
-    Optional<Long> findMemberIdBySocial(Long socialId);
+    Optional<Long> findMemberIdBySocial(String socialId);
 }

--- a/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
@@ -12,5 +12,5 @@ public interface GoogleOAuthRepository
             right join go.member m
             where go.id = :socialId
             """)
-    Optional<Long> findMemberIdBySocial(Long socialId);
+    Optional<Long> findMemberIdBySocial(String socialId);
 }

--- a/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
@@ -5,12 +5,12 @@ import org.leisureup.member.internal.domain.*;
 import org.springframework.data.jpa.repository.*;
 
 public interface KakaoOAuthRepository
-        extends JpaRepository<KakaoOAuth, Long> {
+        extends JpaRepository<KakaoOAuth, String> {
 
     @Query("""
             select m.id from KakaoOAuth ko
             right join ko.member m
             where ko.id = :socialId
             """)
-    Optional<Long> findMemberIdBySocial(Long socialId);
+    Optional<Long> findMemberIdBySocial(String socialId);
 }

--- a/src/main/java/org/leisureup/member/spi/MemberSpi.java
+++ b/src/main/java/org/leisureup/member/spi/MemberSpi.java
@@ -14,7 +14,7 @@ public interface MemberSpi {
      * 주어진 정보로 DB 에 저장된 사용자 ID 를 제공
      */
     Optional<Long> getMemberIdWithSocial(
-            SocialType type, Long socialId
+            SocialType type, String socialId
     );
 
     /**
@@ -22,7 +22,7 @@ public interface MemberSpi {
      */
     @Transactional
     Long saveNewMember(
-            SocialType type, Long socialId,
+            SocialType type, String socialId,
             String nickname, String email
     );
 }

--- a/src/main/java/org/leisureup/member/spi/internal/AppleSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/AppleSocialAuth.java
@@ -15,7 +15,7 @@ public class AppleSocialAuth implements SocialAuth {
     private final AppleOAuthRepository repository;
 
     @Override
-    public Optional<Long> findMemberIdBySocial(Long socialId) {
+    public Optional<Long> findMemberIdBySocial(String socialId) {
         return repository.findMemberIdBySocial(socialId);
     }
 
@@ -26,7 +26,7 @@ public class AppleSocialAuth implements SocialAuth {
 
     @Override
     @Transactional
-    public void save(Long socialId, Member member) {
+    public void save(String socialId, Member member) {
         repository.save(AppleOAuth.of(socialId, member));
     }
 }

--- a/src/main/java/org/leisureup/member/spi/internal/GoogleSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/GoogleSocialAuth.java
@@ -15,7 +15,7 @@ public class GoogleSocialAuth implements SocialAuth {
     private final GoogleOAuthRepository repository;
 
     @Override
-    public Optional<Long> findMemberIdBySocial(Long socialId) {
+    public Optional<Long> findMemberIdBySocial(String socialId) {
         return repository.findMemberIdBySocial(socialId);
     }
 
@@ -26,7 +26,7 @@ public class GoogleSocialAuth implements SocialAuth {
 
     @Override
     @Transactional
-    public void save(Long socialId, Member member) {
+    public void save(String socialId, Member member) {
         repository.save(GoogleOAuth.of(socialId, member));
     }
 }

--- a/src/main/java/org/leisureup/member/spi/internal/KakaoSocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/KakaoSocialAuth.java
@@ -15,7 +15,7 @@ public class KakaoSocialAuth implements SocialAuth {
     private final KakaoOAuthRepository repository;
 
     @Override
-    public Optional<Long> findMemberIdBySocial(Long socialId) {
+    public Optional<Long> findMemberIdBySocial(String socialId) {
         return repository.findMemberIdBySocial(socialId);
     }
 
@@ -26,7 +26,7 @@ public class KakaoSocialAuth implements SocialAuth {
 
     @Override
     @Transactional
-    public void save(Long socialId, Member member) {
+    public void save(String socialId, Member member) {
         repository.save(KakaoOAuth.of(socialId, member));
     }
 }

--- a/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
+++ b/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
@@ -30,13 +30,13 @@ public class MemberSpiImpl implements MemberSpi {
     }
 
     @Override
-    public Optional<Long> getMemberIdWithSocial(SocialType type, Long socialId) {
+    public Optional<Long> getMemberIdWithSocial(SocialType type, String socialId) {
         return socialAuths.get(type).findMemberIdBySocial(socialId);
     }
 
     @Override
     public Long saveNewMember(
-            SocialType type, Long socialId,
+            SocialType type, String socialId,
             String nickname, String email
     ) {
         Member save = memberRepo.save(Member.of(nickname, email));

--- a/src/main/java/org/leisureup/member/spi/internal/SocialAuth.java
+++ b/src/main/java/org/leisureup/member/spi/internal/SocialAuth.java
@@ -10,7 +10,7 @@ public interface SocialAuth {
     /**
      * {@code socialId} 를 통해 DB 에 저장된 사용자 ID 를 제공
      */
-    Optional<Long> findMemberIdBySocial(Long socialId);
+    Optional<Long> findMemberIdBySocial(String socialId);
 
     SocialType getSocialAuthType();
 
@@ -18,5 +18,5 @@ public interface SocialAuth {
      * 소셜 인증 repository 에 해당 정보를 생성 (회원가입용)
      */
     @Transactional
-    void save(Long socialId, Member member);
+    void save(String socialId, Member member);
 }

--- a/src/test/java/org/leisureup/global/auth/social/SocialAuthServiceTest.java
+++ b/src/test/java/org/leisureup/global/auth/social/SocialAuthServiceTest.java
@@ -23,9 +23,9 @@ class SocialAuthServiceTest extends IntegrationTestSupport {
 
     private static final String preAssignedToken = "사용자는 이전에 가입했었다.";
     private static final String newSocialToken = "사용자는 현재 처음 가입중이다.";
-    private static final Long kakaoSignIn = 1L, kakaoSignUp = 2L;
-    private static final Long appleSignIn = 3L, appleSignUp = 4L;
-    private static final Long googleSignIn = 5L, googleSignUp = 6L;
+    private static final String kakaoSignIn = "1", kakaoSignUp = "2";
+    private static final String appleSignIn = "3", appleSignUp = "4";
+    private static final String googleSignIn = "5", googleSignUp = "6";
     private static Long memberId;
     @Autowired
     SocialAuthService socialAuthService;
@@ -136,7 +136,7 @@ class SocialAuthServiceTest extends IntegrationTestSupport {
                 .isPresent();
     }
 
-    void setupOAuthClientMock(Long idOnSignIn, Long idOnSignUp, OAuthClient client) {
+    void setupOAuthClientMock(String idOnSignIn, String idOnSignUp, OAuthClient client) {
         when(client.fetchInfo(anyString()))
                 .thenAnswer(invocation -> {
                     String token = invocation.getArgument(0, String.class);

--- a/src/test/java/org/leisureup/global/auth/social/SocialAuthServiceTest.java
+++ b/src/test/java/org/leisureup/global/auth/social/SocialAuthServiceTest.java
@@ -113,7 +113,7 @@ class SocialAuthServiceTest extends IntegrationTestSupport {
     @MethodSource("signUpRequests")
     @DisplayName("가입하지 않은 사용자는 소셜 인증을 통해 가입할 수 있다.")
     void signUp(SignInUpRequest req) {
-        log.info("start");
+
         var response = socialAuthService.signInOrSignUp(req);
         Long newMemberId = response.id();
 
@@ -137,17 +137,18 @@ class SocialAuthServiceTest extends IntegrationTestSupport {
     }
 
     void setupOAuthClientMock(String idOnSignIn, String idOnSignUp, OAuthClient client) {
-        when(client.fetchInfo(anyString()))
-                .thenAnswer(invocation -> {
-                    String token = invocation.getArgument(0, String.class);
 
-                    if (preAssignedToken.equals(token)) {
-                        return OAuthResponse.of(idOnSignIn, "signIn", "signIn");
-                    } else if (newSocialToken.equals(token)) {
-                        return OAuthResponse.of(idOnSignUp, "signUp", "signUp");
-                    }
+        doAnswer(invocation -> {
+            String token = invocation.getArgument(0, String.class);
 
-                    throw new RuntimeException();
-                });
+            if (preAssignedToken.equals(token)) {
+                return OAuthResponse.of(idOnSignIn, "signIn", "signIn");
+            } else if (newSocialToken.equals(token)) {
+                return OAuthResponse.of(idOnSignUp, "signUp", "signUp");
+            }
+
+            throw new RuntimeException();
+        }).when(client).fetchInfo(anyString());
+
     }
 }

--- a/src/test/java/org/leisureup/member/spi/MemberSpiTest.java
+++ b/src/test/java/org/leisureup/member/spi/MemberSpiTest.java
@@ -20,12 +20,12 @@ import org.springframework.test.context.bean.override.mockito.*;
 class MemberSpiTest extends IntegrationTestSupport {
 
     private static final Long memberId = 1L;
-    private static final Long validKakaoId = 1L,
-            validGoogleId = 2L,
-            validAppleId = 3L;
-    private static final Long invalidKakaoId = 4L,
-            invalidGoogleId = 5L,
-            invalidAppleId = 6L;
+    private static final String validKakaoId = "1",
+            validGoogleId = "2",
+            validAppleId = "3";
+    private static final String invalidKakaoId = "4",
+            invalidGoogleId = "5",
+            invalidAppleId = "6";
     @Autowired
     MemberSpi memberSpi;
     @Autowired
@@ -62,24 +62,24 @@ class MemberSpiTest extends IntegrationTestSupport {
     }
 
     private static Optional<Long> setupMockAnswer(
-            Long validId, InvocationOnMock invocation
+            String validId, InvocationOnMock invocation
     ) {
-        Long id = invocation.getArgument(0, Long.class);
+        String id = invocation.getArgument(0, String.class);
         Long result = validId.equals(id) ? memberId : null;
         return Optional.ofNullable(result);
     }
 
     @BeforeEach
     void setUp() {
-        when(kakaoOAuthRepo.findMemberIdBySocial(anyLong()))
+        when(kakaoOAuthRepo.findMemberIdBySocial(anyString()))
                 .thenAnswer(invocation ->
                         setupMockAnswer(validKakaoId, invocation));
 
-        when(googleOAuthRepo.findMemberIdBySocial(anyLong()))
+        when(googleOAuthRepo.findMemberIdBySocial(anyString()))
                 .thenAnswer(invocation ->
                         setupMockAnswer(validGoogleId, invocation));
 
-        when(appleOAuthRepo.findMemberIdBySocial(anyLong()))
+        when(appleOAuthRepo.findMemberIdBySocial(anyString()))
                 .thenAnswer(invocation ->
                         setupMockAnswer(validAppleId, invocation));
     }
@@ -87,7 +87,7 @@ class MemberSpiTest extends IntegrationTestSupport {
     @ParameterizedTest
     @MethodSource("validSocialArgs")
     @DisplayName("등록된 유저는 소셜인증 타입과 번호에 따라 번호를 식별할 수 있다.")
-    void getMemberId(SocialType type, Long socialId) {
+    void getMemberId(SocialType type, String socialId) {
 
         Optional<Long> id = memberSpi.getMemberIdWithSocial(type, socialId);
 
@@ -98,7 +98,7 @@ class MemberSpiTest extends IntegrationTestSupport {
     @ParameterizedTest
     @MethodSource("invalidSocialArgs")
     @DisplayName("등록되지 않은 유저는 번호를 식별할 수 없다.")
-    void cannotGetMemberId(SocialType type, Long socialId) {
+    void cannotGetMemberId(SocialType type, String socialId) {
 
         Optional<Long> id = memberSpi.getMemberIdWithSocial(type, socialId);
 
@@ -108,7 +108,7 @@ class MemberSpiTest extends IntegrationTestSupport {
     @ParameterizedTest
     @MethodSource("createNewMemberArgs")
     @DisplayName("소셜 인증 타입에 따라 새로운 사용자를 생성할 수 있다.")
-    void createNewMember(SocialType type, Long socialId) {
+    void createNewMember(SocialType type, String socialId) {
 
         String name = "test", email = "test@email";
         Long id = memberSpi.saveNewMember(type, socialId, name, email);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

OAuth2 작업을 진행하다 Google 의 사용자 식별자 `sub` 가 `Long` 범위를 초과하는 것을 발견했습니다.
그래서 관련 DTO, Entity 의 식별자 타입을 `Long` 에서 `String` 으로 모두 변경했습니다.

또한 `SocialAuthServiceTest` 에서 spy bean mocking 이 잘못된 것을 확인해 수정하였습니다.

(Spy bean 에서 `when(...).thenAnswer(...)` 는 실제 메서드를 한번 호출 후 mocking 됨)

## 💬 리뷰 요구사항 (선택)

큰 이상이 없으면 내일까지 merge 하겠습니다.