### PR TITLE
Feat/member - 사용자 찜 관련 기능 추가

### DIFF
--- a/src/main/java/org/leisureup/global/auth/controller/AuthController.java
+++ b/src/main/java/org/leisureup/global/auth/controller/AuthController.java
@@ -9,6 +9,8 @@ import org.leisureup.global.auth.dto.response.*;
 import org.leisureup.global.auth.social.*;
 import org.leisureup.global.auth.token.service.*;
 import org.leisureup.global.response.*;
+import org.leisureup.member.spi.*;
+import org.springframework.context.annotation.*;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -19,9 +21,10 @@ public class AuthController {
 
     private final SocialAuthService socialAuthService;
     private final TokenAuthService tokenAuthService;
+    private final MemberSpi memberSpi;
 
-    // 소셜 로그인 or 회원가입
-    @PostMapping
+
+    @PostMapping            // 소셜 로그인 or 회원가입
     public ApiResponse<SignInUpResponse> loginSingUp(
             @Valid @RequestBody SignInUpRequest req
     ) {
@@ -33,8 +36,8 @@ public class AuthController {
         );
     }
 
-    // 토큰 재발급
-    @PostMapping("/token")
+
+    @PostMapping("/token")  // 토큰 재발급
     public ApiResponse<RecreateTokenResponse> recreateToken(
             @Valid @RequestBody RecreateTokenRequest req
     ) {
@@ -47,4 +50,17 @@ public class AuthController {
         );
     }
 
+    @Profile("local")
+    @PostMapping("/new")
+    public ApiResponse<SignInUpResponse> createNewMember(
+            @RequestParam SocialType type, @RequestParam String socialId,
+            @RequestParam String nickname, @RequestParam String email
+    ) {
+        Long id = memberSpi.saveNewMember(type, socialId, nickname, email);
+        Tokens t = tokenAuthService.createTokens(id);
+        return ApiResponse.success(
+                201,
+                SignInUpResponse.of(id, t.accessToken(), t.refreshToken())
+        );
+    }
 }

--- a/src/main/java/org/leisureup/global/exception/DuplicatePickException.java
+++ b/src/main/java/org/leisureup/global/exception/DuplicatePickException.java
@@ -1,0 +1,8 @@
+package org.leisureup.global.exception;
+
+public class DuplicatePickException extends CustomException {
+
+    public DuplicatePickException(String message) {
+        super(409, message);
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -3,6 +3,7 @@ package org.leisureup.member.internal.controller;
 import jakarta.validation.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
+import org.leisureup.global.*;
 import org.leisureup.global.exception.*;
 import org.leisureup.global.response.*;
 import org.leisureup.member.internal.dto.request.*;
@@ -16,9 +17,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class MemberController {
 
-    // TODO : Request header 의 jwt 로 member id 가져오는 기능 필요
-
     private final MemberService memberService;
+    private final AuthHolder authHolder;
 
     private static PageRequest toPageRequest(int page, int size) {
 
@@ -29,11 +29,12 @@ public class MemberController {
         return PageRequest.of(page, Math.min(size, 100));
     }
 
-    // 멤버 정보 조회
-    @GetMapping
+    @GetMapping     // 멤버 정보 조회
+    @JwtAuthRequired
     public ApiResponse<GetMemberResponse> getMember() {
-        // TODO : 완성하기
-        throw new NotImplemented("API /member not implemented yet");
+        Long memberId = authHolder.getMemberId();
+        GetMemberResponse resp = memberService.getMember(memberId);
+        return ApiResponse.success(200, resp);
     }
 
     // 니즈 수집 질문 응답 저장

--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -47,8 +47,9 @@ public class MemberController {
         throw new NotImplemented("API /member/interest not implemented yet");
     }
 
-    // 찜 목록 조회
-    @GetMapping("/picks")
+
+    @GetMapping("/picks")       // 찜 목록 조회
+    @JwtAuthRequired
     public ApiResponse<PageResponse<PickLocation>> getPickLocations(
             @RequestParam(value = "page", defaultValue = "0")
             int page,
@@ -56,8 +57,10 @@ public class MemberController {
             int size
     ) {
         PageRequest req = toPageRequest(page, size);
-        // TODO : 완성하기
-        throw new NotImplemented("API /member/picks (GET) not implemented yet");
+        Long memberId = authHolder.getMemberId();
+
+        var resp = memberService.getPickLocations(memberId, req);
+        return ApiResponse.success(200, resp);
     }
 
     // 장소 찜 저장

--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -75,13 +75,16 @@ public class MemberController {
         return ApiResponse.success(201, null);
     }
 
-    // 찜 장소 삭제
-    @DeleteMapping("/picks/{locationId}")
+
+    @DeleteMapping("/picks/{locationId}")       // 찜 장소 삭제
+    @JwtAuthRequired
     public ApiResponse<?> deletePickLocation(
             @Valid @Positive @NotNull
             @PathVariable Long locationId
     ) {
-        // TODO : 완성하기
-        throw new NotImplemented("API /member/pick/{locationId} not implemented yet");
+        Long memberId = authHolder.getMemberId();
+        memberService.deletePickLocation(memberId, locationId);
+
+        return ApiResponse.success(204, null);
     }
 }

--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -63,13 +63,16 @@ public class MemberController {
         return ApiResponse.success(200, resp);
     }
 
-    // 장소 찜 저장
-    @PostMapping("/picks")
+
+    @PostMapping("/picks")      // 장소 찜 저장
+    @JwtAuthRequired
     public ApiResponse<?> savePickLocation(
-            @Valid SavePickLocationRequest req
+            @Valid @RequestBody SavePickLocationRequest req
     ) {
-        // TODO : 완성하기
-        throw new NotImplemented("API /member/picks (POST) not implemented yet");
+        Long memberId = authHolder.getMemberId();
+        memberService.savePickLocation(memberId, req);
+
+        return ApiResponse.success(201, null);
     }
 
     // 찜 장소 삭제

--- a/src/main/java/org/leisureup/member/internal/domain/Pick.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Pick.java
@@ -20,4 +20,13 @@ public class Pick extends BaseTimeEntity {
     @Id
     @Column(name = "b_location_id", nullable = false, updatable = false)
     private long locationId;
+
+    private Pick(Member member, long locationId) {
+        this.member = member;
+        this.locationId = locationId;
+    }
+
+    public static Pick of(Member member, long locationId) {
+        return new Pick(member, locationId);
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/dto/response/PageResponse.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/PageResponse.java
@@ -1,6 +1,7 @@
 package org.leisureup.member.internal.dto.response;
 
 import java.util.*;
+import org.springframework.data.domain.*;
 
 public record PageResponse<T>(
         long totalPages,
@@ -10,4 +11,11 @@ public record PageResponse<T>(
         List<T> elements
 ) {
 
+    public static <T> PageResponse<T> of(Page<?> page, List<T> elements) {
+        return new PageResponse<>(
+                page.getTotalPages(), page.getNumber(),
+                page.getSize(), page.isLast(),
+                elements
+        );
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/dto/response/PickLocation.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/PickLocation.java
@@ -1,5 +1,7 @@
 package org.leisureup.member.internal.dto.response;
 
+import org.leisureup.location.spi.*;
+
 public record PickLocation(
         Long id,
         String name,
@@ -10,5 +12,24 @@ public record PickLocation(
 
     public enum Category {
         EARTH, WATER, SKY, OTHER
+    }
+
+    public static PickLocation of(LocationResponse lResp) {
+
+        Long id = lResp.locationId();
+        String name = lResp.title();
+
+        Desc desc = lResp.description();
+        String th1 = desc.largeThumbnail();
+        String th2 = desc.smallThumbnail();
+
+        Category cat = switch (lResp.category()) {
+            case EARTH -> Category.EARTH;
+            case WATER -> Category.WATER;
+            case SKY -> Category.SKY;
+            default -> Category.OTHER;
+        };
+
+        return new PickLocation(id, name, th1, th2, cat);
     }
 }

--- a/src/main/java/org/leisureup/member/internal/dto/response/PickLocation.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/PickLocation.java
@@ -20,16 +20,23 @@ public record PickLocation(
         String name = lResp.title();
 
         Desc desc = lResp.description();
-        String th1 = desc.largeThumbnail();
-        String th2 = desc.smallThumbnail();
+        String th1 = desc != null ? desc.largeThumbnail() : "";
+        String th2 = desc != null ? desc.smallThumbnail() : "";
 
-        Category cat = switch (lResp.category()) {
-            case EARTH -> Category.EARTH;
-            case WATER -> Category.WATER;
-            case SKY -> Category.SKY;
-            default -> Category.OTHER;
-        };
+        Category category;
+        Cat cat = lResp.category();
 
-        return new PickLocation(id, name, th1, th2, cat);
+        if (cat == null) {
+            category = Category.OTHER;
+        } else {
+            category = switch (cat) {
+                case EARTH -> Category.EARTH;
+                case WATER -> Category.WATER;
+                case SKY -> Category.SKY;
+                default -> Category.OTHER;
+            };
+        }
+
+        return new PickLocation(id, name, th1, th2, category);
     }
 }

--- a/src/main/java/org/leisureup/member/internal/repository/PickRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/PickRepository.java
@@ -1,0 +1,21 @@
+package org.leisureup.member.internal.repository;
+
+import org.leisureup.member.internal.domain.*;
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface PickRepository extends JpaRepository<Pick, PickCompositeKey> {
+
+    @Query(
+            value = """
+                    select p from Pick p
+                    where p.member.id = :memberId
+                    order by p.createdAt
+                    """,
+            countQuery = """
+                    select count(p) from Pick p
+                    """
+    )
+    Page<Pick> findAllByMemberId(Long memberId, Pageable pageable);
+
+}

--- a/src/main/java/org/leisureup/member/internal/service/MemberService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberService.java
@@ -17,6 +17,9 @@ public class MemberService {
     private final MemberRepository memberRepo;
     private final InterestRepository interestRepo;
 
+    /**
+     * 사용자 정보를 조회한다.
+     */
     public GetMemberResponse getMember(Long memberId) {
         Member find = memberRepo.findById(memberId)
                 .orElseThrow(() -> new NotFound("Member not found"));

--- a/src/main/java/org/leisureup/member/internal/service/MemberService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberService.java
@@ -1,6 +1,5 @@
 package org.leisureup.member.internal.service;
 
-import jakarta.transaction.*;
 import java.util.*;
 import lombok.*;
 import org.leisureup.global.exception.*;
@@ -11,6 +10,7 @@ import org.leisureup.member.internal.dto.response.*;
 import org.leisureup.member.internal.repository.*;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
 
 @Service
 @RequiredArgsConstructor
@@ -77,4 +77,27 @@ public class MemberService {
         return PageResponse.of(pickLocations, contents);
     }
 
+    /**
+     * 어느 장소를 찜 목록에 저장한다.
+     */
+    @Transactional
+    public void savePickLocation(Long memberId, SavePickLocationRequest req) {
+
+        Long locationId = req.locationId();
+
+        if (locationQueryPort.notExists(locationId)) {
+            throw new NotFound("Location not found");
+        }
+
+        Member find = memberRepo.findById(memberId)
+                .orElseThrow(() -> new NotFound("Member not found"));
+
+        PickCompositeKey key = new PickCompositeKey(find, locationId);
+        if (pickRepo.existsById(key)) {
+            throw new DuplicatePickException("Pick already exists");
+        }
+
+        Pick newPick = Pick.of(find, locationId);
+        pickRepo.save(newPick);
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/service/MemberService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberService.java
@@ -100,4 +100,20 @@ public class MemberService {
         Pick newPick = Pick.of(find, locationId);
         pickRepo.save(newPick);
     }
+
+    /**
+     * 찜 목록의 어느 장소를 삭제한다.
+     */
+    @Transactional
+    public void deletePickLocation(Long memberId, Long locationId) {
+
+        Member find = memberRepo.findById(memberId)
+                .orElseThrow(() -> new NotFound("Member not found"));
+
+        PickCompositeKey key = new PickCompositeKey(find, locationId);
+        Pick pick = pickRepo.findById(key)
+                .orElseThrow(() -> new NotFound("Pick not found"));
+
+        pickRepo.delete(pick);
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/service/MemberService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberService.java
@@ -4,10 +4,12 @@ import jakarta.transaction.*;
 import java.util.*;
 import lombok.*;
 import org.leisureup.global.exception.*;
+import org.leisureup.location.spi.*;
 import org.leisureup.member.internal.domain.*;
 import org.leisureup.member.internal.dto.request.*;
 import org.leisureup.member.internal.dto.response.*;
 import org.leisureup.member.internal.repository.*;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.*;
 
 @Service
@@ -16,6 +18,8 @@ public class MemberService {
 
     private final MemberRepository memberRepo;
     private final InterestRepository interestRepo;
+    private final PickRepository pickRepo;
+    private final LocationQueryPort locationQueryPort;
 
     /**
      * 사용자 정보를 조회한다.
@@ -47,6 +51,30 @@ public class MemberService {
         }
 
         interestRepo.save(Interest.of(member, savingInfo));
+    }
+
+
+    /**
+     * 사용자 찜 장소 목록을 조회한다.
+     */
+    public PageResponse<PickLocation> getPickLocations(
+            Long memberId, PageRequest req
+    ) {
+        Page<Pick> pickLocations = pickRepo.findAllByMemberId(memberId, req);
+
+        if (pickLocations.isEmpty()) {
+            return PageResponse.of(pickLocations, Collections.emptyList());
+        }
+
+        List<Long> locationIds = pickLocations.map(Pick::getLocationId)
+                .getContent();
+
+        List<PickLocation> contents = locationQueryPort
+                .getLocationListById(locationIds).stream()
+                .map(PickLocation::of)
+                .toList();
+
+        return PageResponse.of(pickLocations, contents);
     }
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,7 +46,7 @@ springdoc:
     enabled: true
     path: /api-doc
     tags-sorter: alpha
-    operations-sorter: method
+    operations-sorter: alpha
     display-request-duration: true
 
   api-docs.path: /api-doc

--- a/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
+++ b/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
@@ -1,28 +1,51 @@
 package org.leisureup.member.internal.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import java.util.*;
+import java.util.stream.*;
+import lombok.*;
 import lombok.extern.slf4j.*;
 import org.junit.jupiter.api.*;
 import org.leisureup.*;
 import org.leisureup.global.exception.*;
+import org.leisureup.location.spi.*;
 import org.leisureup.member.internal.domain.*;
 import org.leisureup.member.internal.dto.request.*;
 import org.leisureup.member.internal.dto.request.SaveInterestRequest.*;
+import org.leisureup.member.internal.dto.response.*;
 import org.leisureup.member.internal.repository.*;
 import org.springframework.beans.factory.annotation.*;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.*;
+import org.springframework.test.context.bean.override.mockito.*;
+import org.springframework.transaction.annotation.*;
 
 @Slf4j
 class MemberServiceTest extends IntegrationTestSupport {
 
     private static final Long invalidMemberId = Long.MAX_VALUE;
     private static Long testMemberId;
+    private static final List<Long> locationIds = LongStream.rangeClosed(1, 10)
+            .boxed().toList();
+    private static final List<LocationResponse> locations
+            = locationIds.stream()
+            .map(MemberServiceTest::locationResponse)
+            .toList();
+    private static final Long existingLocationId = Long.MAX_VALUE / 2;
     @Autowired
     MemberService service;
     @Autowired
     MemberRepository memberRepo;
     @Autowired
     InterestRepository interestRepo;
+    @Autowired
+    PickRepository pickRepo;
+    @Autowired
+    TestInitializer testInitializer;
+    @MockitoBean
+    LocationQueryPort locationQueryPort;
 
     private static SaveInterestRequest genReq(int ageRange) {
         return new SaveInterestRequest(
@@ -32,16 +55,32 @@ class MemberServiceTest extends IntegrationTestSupport {
         );
     }
 
+    private static LocationResponse locationResponse(Long id) {
+        return new LocationResponse(
+                id, String.valueOf(id),
+                null, null, null, null
+        );
+    }
+
     @BeforeEach
     void setUp() {
-        testMemberId = memberRepo.save(
-                Member.of("test", "test")
-        ).getId();
+        Member save = testInitializer.initializeData(locationIds);
+
+        when(locationQueryPort.notExists(anyLong()))
+                .thenAnswer(invocation -> {
+                    Long id = invocation.getArgument(0, Long.class);
+                    return !locationIds.contains(id) && !existingLocationId.equals(id);
+                });
+        when(locationQueryPort.getLocationListById(locationIds))
+                .thenReturn(locations);
+
+        testMemberId = save.getId();
     }
 
     @AfterEach
     void tearDown() {
         interestRepo.deleteAll();
+        pickRepo.deleteAll();
         memberRepo.deleteAll();
     }
 
@@ -69,5 +108,92 @@ class MemberServiceTest extends IntegrationTestSupport {
                 .isInstanceOf(NotFound.class);
         assertThatThrownBy(() -> service.saveInterest(invalidMemberId, req))
                 .isInstanceOf(NotFound.class);
+    }
+
+    @Test
+    @DisplayName("사용자는 찜 장소 목록을 조회할 수 있다.")
+    void getPickLocations() {
+
+        int pageNo = 0, pageSize = locationIds.size();
+        PageRequest pageReq = PageRequest.of(0, pageSize);
+        var response = service.getPickLocations(testMemberId, pageReq);
+
+        assertThat(response).isNotNull();
+        assertThat(response.lastPage()).isTrue();
+        assertThat(response.pageNo()).isEqualTo(pageNo);
+        assertThat(response.pageSize()).isEqualTo(pageSize);
+
+        List<PickLocation> elements = response.elements();
+        assertThat(elements).hasSize(pageSize);
+        assertThat(elements).doesNotContainNull();
+        elements.forEach(e -> assertThat(e).hasNoNullFieldsOrProperties());
+    }
+
+    @Test
+    @DisplayName("사용자는 어느 장소를 찜으로 저장할 수 있다.")
+    void savePickLocation() {
+        var req = new SavePickLocationRequest(existingLocationId);
+        service.savePickLocation(testMemberId, req);
+
+        Member member = memberRepo.findById(testMemberId)
+                .orElseThrow();
+        var key = new PickCompositeKey(member, existingLocationId);
+
+        assertThat(pickRepo.findById(key)).isPresent();
+    }
+
+    @Test
+    @DisplayName("사용자는 자신의 찜 장소를 삭제할 수 있다.")
+    void deletePickLocation() {
+        Long locationId = locationIds.getFirst();
+        service.deletePickLocation(testMemberId, locationId);
+
+        Member member = memberRepo.findById(testMemberId)
+                .orElseThrow();
+        var key = new PickCompositeKey(member, locationId);
+
+        assertThat(pickRepo.findById(key)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("중복된 장소는 찜 저장할 수 없다.")
+    void testDuplicatePick() {
+        var req = new SavePickLocationRequest(locationIds.getFirst());
+
+        assertThatThrownBy(() -> service.savePickLocation(testMemberId, req))
+                .isInstanceOf(DuplicatePickException.class);
+
+    }
+
+    @Test
+    @DisplayName("찜 저장되지 않은 장소는 찜에서 삭제할 수 없다.")
+    void testUnSavedPickDeletion() {
+
+        assertThatThrownBy(() -> service.deletePickLocation(testMemberId, existingLocationId))
+                .isInstanceOf(NotFound.class);
+
+    }
+}
+
+@Component
+@RequiredArgsConstructor
+class TestInitializer {
+
+    private final MemberRepository memberRepo;
+    private final PickRepository pickRepo;
+
+    @Transactional
+    Member initializeData(List<Long> locationIds) {
+        Member save = memberRepo.save(
+                Member.of("test", "test")
+        );
+
+        List<Pick> picks = new ArrayList<>();
+        for (Long locationId : locationIds) {
+            picks.add(Pick.of(save, locationId));
+        }
+        pickRepo.saveAll(picks);
+
+        return save;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

1. `Member` 도메인의 찜 관련 기능을 추가했습니다. `(찜 목록 조회, 장소 추가 및 삭제)`
2. `AuthController` 에 로컬 테스트용 사용자 생성 endpoint 를 구성했습니다. `(@Profile("local"))`

## 💬 리뷰 요구사항 (선택)

`None`