### PR TITLE
Feat/recommend - 사용자 질문에 따른 장소 추천 기능 추가

### DIFF
--- a/src/main/java/org/leisureup/info/recommend/internal/controller/RecommendController.java
+++ b/src/main/java/org/leisureup/info/recommend/internal/controller/RecommendController.java
@@ -1,0 +1,31 @@
+package org.leisureup.info.recommend.internal.controller;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.global.*;
+import org.leisureup.global.response.*;
+import org.leisureup.info.recommend.internal.dto.response.*;
+import org.leisureup.info.recommend.internal.service.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/recommends")
+@RequiredArgsConstructor
+public class RecommendController {
+
+    private final AuthHolder authHolder;
+    private final RecommendService recommendService;
+
+    @JwtAuthIfPossible
+    @GetMapping("/member")  // 사용자 질문 응답 기반 장소 추천
+    public ApiResponse<List<LocationInfo>> recommendOnMember() {
+
+        Long memberId = authHolder.getMemberId();
+
+        return ApiResponse.success(
+                200, memberId == null ?
+                        recommendService.recommendOnAnonymous() :
+                        recommendService.recommendOnMember(memberId)
+        );
+    }
+}

--- a/src/main/java/org/leisureup/info/recommend/internal/dto/PrioritizedCategoryInfo.java
+++ b/src/main/java/org/leisureup/info/recommend/internal/dto/PrioritizedCategoryInfo.java
@@ -1,0 +1,19 @@
+package org.leisureup.info.recommend.internal.dto;
+
+import org.springframework.lang.*;
+
+/**
+ * @param score 높을수록 좋은거
+ */
+public record PrioritizedCategoryInfo(
+        Long categoryId,
+        String name,
+        double score
+) implements Comparable<PrioritizedCategoryInfo> {
+
+    @Override
+    public int compareTo(@NonNull PrioritizedCategoryInfo o) {
+        // 이래야 높은 점수가 head 로 정렬
+        return Double.compare(o.score, score);
+    }
+}

--- a/src/main/java/org/leisureup/info/recommend/internal/dto/response/LocationInfo.java
+++ b/src/main/java/org/leisureup/info/recommend/internal/dto/response/LocationInfo.java
@@ -1,0 +1,14 @@
+package org.leisureup.info.recommend.internal.dto.response;
+
+public record LocationInfo(
+        Long id,
+        String name,
+        String largeThumbnail,
+        String smallThumbnail,
+        Category category
+) {
+
+    public enum Category {
+        EARTH, WATER, SKY, OTHER
+    }
+}

--- a/src/main/java/org/leisureup/info/recommend/internal/service/DefaultScoring.java
+++ b/src/main/java/org/leisureup/info/recommend/internal/service/DefaultScoring.java
@@ -1,0 +1,40 @@
+package org.leisureup.info.recommend.internal.service;
+
+import lombok.extern.slf4j.*;
+
+@Slf4j
+public class DefaultScoring implements Scoring {
+
+    private static final String DELIMITER = "-";
+
+    private static String[] parseCode(String code) {
+        try {
+            return code.split(DELIMITER);
+        } catch (Exception e) {
+            log.warn("Failed to parse code [{}]. Supplying empty array", code, e);
+            return new String[0];
+        }
+    }
+
+    @Override
+    public double score(String one, String second) {
+        String[] parsed1 = parseCode(one);
+        String[] parsed2 = parseCode(second);
+
+        int len = Math.min(parsed1.length, parsed2.length);
+        int score = 0;
+
+        for (int i = 0; i < len; i++) {
+            String st1 = parsed1[i];
+            String st2 = parsed2[i];
+
+            if (st1.equals(st2)) {
+                score += 2;
+            } else if (st1.contains(st2) || st2.contains(st1)) {
+                score++;
+            }
+        }
+
+        return score;
+    }
+}

--- a/src/main/java/org/leisureup/info/recommend/internal/service/PrioritizingService.java
+++ b/src/main/java/org/leisureup/info/recommend/internal/service/PrioritizingService.java
@@ -1,0 +1,54 @@
+package org.leisureup.info.recommend.internal.service;
+
+import java.util.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.leisureup.info.recommend.internal.dto.*;
+import org.leisureup.location.spi.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PrioritizingService {
+
+    private final Scoring scoring;
+
+    /**
+     * 사용자 관심 코드에 맞춰 카테고리 중 상위 {@code truncate} 개만 추려 반환한다.
+     */
+    public List<PrioritizedCategoryInfo> prioritize(
+            InterestCode memberCode, List<CategoryInfo> categories,
+            int truncate
+    ) {
+
+        if (truncate <= 0) {
+            throw new IllegalArgumentException("Truncate must be greater than zero");
+        }
+
+        if (categories.size() < truncate) {
+            log.warn("Given categories are less than truncate");
+        }
+
+        return categories.stream()
+                .map(c -> convert(memberCode, c))
+                .sorted()
+                .limit(truncate)
+                .toList();
+    }
+
+    private PrioritizedCategoryInfo convert(
+            InterestCode memberCode, CategoryInfo category
+    ) {
+        Long id = category.id();
+        String name = category.name();
+
+        String code1 = memberCode.code();
+        String code2 = category.recommendingCode();
+
+        return new PrioritizedCategoryInfo(
+                id, name, scoring.score(code1, code2)
+        );
+    }
+}

--- a/src/main/java/org/leisureup/info/recommend/internal/service/RecommendService.java
+++ b/src/main/java/org/leisureup/info/recommend/internal/service/RecommendService.java
@@ -1,0 +1,103 @@
+package org.leisureup.info.recommend.internal.service;
+
+import java.util.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.leisureup.info.recommend.internal.dto.*;
+import org.leisureup.info.recommend.internal.dto.response.*;
+import org.leisureup.info.recommend.internal.dto.response.LocationInfo.*;
+import org.leisureup.location.spi.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecommendService {
+
+    private static final int DEFAULT_RECOMMENDING_SIZE = 50;
+    private static final int DEFAULT_RECOMMENDING_CATEGORY_SIZE = 5;
+    private final MemberSpi memberSpi;
+    private final CategorySpi categorySpi;
+    private final LocationQueryPort locationQueryPort;
+    private final PrioritizingService prioritizingService;
+
+    /**
+     * 로그인 하지 않은 사용자에게 장소를 추천
+     */
+    public List<LocationInfo> recommendOnAnonymous() {
+
+        List<LocationResponse> locations
+                = locationQueryPort.getAnyLocations(DEFAULT_RECOMMENDING_SIZE);
+
+        return locations.stream()
+                .map(RecommendServiceUtil::convert)
+                .toList();
+    }
+
+
+    /**
+     * 로그인한 사용자에게 장소를 추천
+     */
+    public List<LocationInfo> recommendOnMember(
+            Long memberId
+    ) {
+
+        Optional<InterestCode> optional = memberSpi.getInterest(memberId);
+
+        // 질문 응답을 한지 않았으면 그냥 평이한 장소 추천
+        if (optional.isEmpty()) {
+            return this.recommendOnAnonymous();
+        }
+
+        // 모든 카테고리 중
+        List<CategoryInfo> allCategories = categorySpi.getAllCategories();
+
+        // 사용자가 관심있는 카테고리 ID 만 끌어낸다.
+        List<Long> categoriesInInterest = prioritizingService.prioritize(
+                        optional.get(), allCategories,
+                        DEFAULT_RECOMMENDING_CATEGORY_SIZE
+                ).stream().map(PrioritizedCategoryInfo::categoryId)
+                .toList();
+
+        // 정보 조회해 반환한다.
+        return locationQueryPort.getAnyLocationsOnCategory(
+                        DEFAULT_RECOMMENDING_SIZE, categoriesInInterest
+                ).stream().map(RecommendServiceUtil::convert)
+                .toList();
+    }
+}
+
+
+class RecommendServiceUtil {
+
+    static LocationInfo convert(LocationResponse location) {
+        Long id = location.locationId();
+        String name = location.title();
+        var desc = location.description();
+        String th1 = null, th2 = null;
+        Category category = resolveCategory(location.category());
+
+        if (desc != null) {
+            th1 = desc.largeThumbnail();
+            th2 = desc.smallThumbnail();
+        }
+
+        return new LocationInfo(
+                id, name, emptyIfNull(th1), emptyIfNull(th2), category
+        );
+    }
+
+    private static Category resolveCategory(Cat cat) {
+        return switch (cat) {
+            case EARTH -> Category.EARTH;
+            case WATER -> Category.WATER;
+            case SKY -> Category.SKY;
+            default -> Category.OTHER;
+        };
+    }
+
+    private static String emptyIfNull(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/src/main/java/org/leisureup/info/recommend/internal/service/Scoring.java
+++ b/src/main/java/org/leisureup/info/recommend/internal/service/Scoring.java
@@ -1,0 +1,9 @@
+package org.leisureup.info.recommend.internal.service;
+
+/**
+ * 두 문자열간 유사성 점수를 제공하는 계약
+ */
+public interface Scoring {
+
+    double score(String one, String second);
+}

--- a/src/main/java/org/leisureup/info/recommend/internal/service/ScoringConfig.java
+++ b/src/main/java/org/leisureup/info/recommend/internal/service/ScoringConfig.java
@@ -1,0 +1,12 @@
+package org.leisureup.info.recommend.internal.service;
+
+import org.springframework.context.annotation.*;
+
+@Configuration
+public class ScoringConfig {
+
+    @Bean
+    public Scoring scoring() {
+        return new DefaultScoring();
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/repository/LocationRepository.java
+++ b/src/main/java/org/leisureup/location/internal/repository/LocationRepository.java
@@ -9,21 +9,21 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 
     @Query("""
             select l from Location l
-            right join fetch l.locationCategory
+            inner join fetch l.locationCategory
             where l.id = :id
             """)
     Optional<Location> findByIdFetchingCategory(Long id);
 
     @Query("""
             select l from Location l
-            right join fetch l.locationCategory
+            inner join fetch l.locationCategory
             where l.id in :locationIds
             """)
     List<Location> findAllByLocationIds(List<Long> locationIds);
 
     @Query("""
             select l from Location l
-            right join fetch l.locationCategory
+            inner join fetch l.locationCategory
             """)
     List<Location> findAllBy(Pageable pageable);
 
@@ -35,7 +35,7 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
 
     @Query("""
             select l from Location l
-            right join fetch l.locationCategory
+            inner join fetch l.locationCategory
             where l.locationCategory.id in :categoryIds
             """)
     List<Location> findAllByCategories(Pageable pageable, List<Long> categoryIds);

--- a/src/main/java/org/leisureup/location/internal/repository/LocationRepository.java
+++ b/src/main/java/org/leisureup/location/internal/repository/LocationRepository.java
@@ -2,6 +2,7 @@ package org.leisureup.location.internal.repository;
 
 import java.util.*;
 import org.leisureup.location.internal.domain.*;
+import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.*;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
@@ -20,4 +21,22 @@ public interface LocationRepository extends JpaRepository<Location, Long> {
             """)
     List<Location> findAllByLocationIds(List<Long> locationIds);
 
+    @Query("""
+            select l from Location l
+            right join fetch l.locationCategory
+            """)
+    List<Location> findAllBy(Pageable pageable);
+
+    @Query("""
+            select count(l) from Location l
+            where l.locationCategory.id in :categoryIds
+            """)
+    long countByCategories(List<Long> categoryIds);
+
+    @Query("""
+            select l from Location l
+            right join fetch l.locationCategory
+            where l.locationCategory.id in :categoryIds
+            """)
+    List<Location> findAllByCategories(Pageable pageable, List<Long> categoryIds);
 }

--- a/src/main/java/org/leisureup/location/spi/LocationQueryPort.java
+++ b/src/main/java/org/leisureup/location/spi/LocationQueryPort.java
@@ -4,11 +4,37 @@ import java.util.*;
 
 public interface LocationQueryPort {
 
+    /**
+     * 어느 한 장소의 정보를 조회
+     */
     LocationResponse getLocationById(Long locationId);
 
+    /**
+     * 제공된 ID 목록에 해당하는 장소들의 정보를 조회
+     */
     List<LocationResponse> getLocationListById(
             List<Long> locationIds
     );
 
+    /**
+     * ID 에 해당하는 장소가 없는지 확인
+     */
     boolean notExists(Long locationId);
+
+    /**
+     * 최대 {@code maxElements} 만큼의 장소 정보를 조회.
+     * <p>
+     * 조회되는 장소는 랜덤하게 변할 수 있음.
+     */
+    List<LocationResponse> getAnyLocations(int maxElements);
+
+    /**
+     * {@code categoryIds} 에 속한 장소 중, 최대 {@code maxElements} 만큼의 장소 정보를 조회.
+     * <p>
+     * 조회되는 장소는 랜덤하게 변할 수 있음.
+     */
+    List<LocationResponse> getAnyLocationsOnCategory(
+            int maxElements, List<Long> categoryIds
+    );
+
 }

--- a/src/main/java/org/leisureup/location/spi/internal/LocationQueryAdapter.java
+++ b/src/main/java/org/leisureup/location/spi/internal/LocationQueryAdapter.java
@@ -1,6 +1,7 @@
 package org.leisureup.location.spi.internal;
 
 import java.util.*;
+import java.util.concurrent.*;
 import java.util.stream.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
@@ -8,6 +9,7 @@ import org.leisureup.global.exception.*;
 import org.leisureup.location.internal.domain.*;
 import org.leisureup.location.internal.repository.*;
 import org.leisureup.location.spi.*;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.*;
 
 @Slf4j
@@ -16,6 +18,8 @@ import org.springframework.stereotype.*;
 public class LocationQueryAdapter implements LocationQueryPort {
 
     private final LocationRepository locationRepo;
+
+    private static final Random RAND = ThreadLocalRandom.current();
 
     @Override
     public LocationResponse getLocationById(Long locationId) {
@@ -59,6 +63,46 @@ public class LocationQueryAdapter implements LocationQueryPort {
     @Override
     public boolean notExists(Long locationId) {
         return !locationRepo.existsById(locationId);
+    }
+
+    private static PageRequest randomPageRequest(
+            int numOfElementsToInclude, long totalElements
+    ) {
+        int total = totalElements > Integer.MAX_VALUE ?
+                Integer.MAX_VALUE : (int) totalElements;
+
+        int totalPages = Math.ceilDiv(total, numOfElementsToInclude);
+        int randomPage = RAND.nextInt(totalPages + 1);
+
+        return PageRequest.of(randomPage, numOfElementsToInclude);
+    }
+
+    @Override
+    public List<LocationResponse> getAnyLocations(int maxElements) {
+        long cnt = locationRepo.count();
+
+        List<Location> locations = locationRepo.findAllBy(
+                randomPageRequest(maxElements, cnt)
+        );
+
+        return locations.stream()
+                .map(LocationUtils::toRecord)
+                .toList();
+    }
+
+    @Override
+    public List<LocationResponse> getAnyLocationsOnCategory(
+            int maxElements, List<Long> categoryIds
+    ) {
+        long cnt = locationRepo.countByCategories(categoryIds);
+
+        List<Location> locations = locationRepo.findAllByCategories(
+                randomPageRequest(maxElements, cnt), categoryIds
+        );
+
+        return locations.stream()
+                .map(LocationUtils::toRecord)
+                .toList();
     }
 }
 

--- a/src/main/java/org/leisureup/location/spi/internal/LocationQueryAdapter.java
+++ b/src/main/java/org/leisureup/location/spi/internal/LocationQueryAdapter.java
@@ -19,8 +19,6 @@ public class LocationQueryAdapter implements LocationQueryPort {
 
     private final LocationRepository locationRepo;
 
-    private static final Random RAND = ThreadLocalRandom.current();
-
     @Override
     public LocationResponse getLocationById(Long locationId) {
 
@@ -65,24 +63,16 @@ public class LocationQueryAdapter implements LocationQueryPort {
         return !locationRepo.existsById(locationId);
     }
 
-    private static PageRequest randomPageRequest(
-            int numOfElementsToInclude, long totalElements
-    ) {
-        int total = totalElements > Integer.MAX_VALUE ?
-                Integer.MAX_VALUE : (int) totalElements;
-
-        int totalPages = Math.ceilDiv(total, numOfElementsToInclude);
-        int randomPage = RAND.nextInt(totalPages + 1);
-
-        return PageRequest.of(randomPage, numOfElementsToInclude);
-    }
-
     @Override
     public List<LocationResponse> getAnyLocations(int maxElements) {
         long cnt = locationRepo.count();
 
+        if (cnt == 0) {
+            return Collections.emptyList();
+        }
+
         List<Location> locations = locationRepo.findAllBy(
-                randomPageRequest(maxElements, cnt)
+                LocationUtils.randomPageRequest(maxElements, cnt)
         );
 
         return locations.stream()
@@ -96,8 +86,12 @@ public class LocationQueryAdapter implements LocationQueryPort {
     ) {
         long cnt = locationRepo.countByCategories(categoryIds);
 
+        if (cnt == 0) {
+            return Collections.emptyList();
+        }
+
         List<Location> locations = locationRepo.findAllByCategories(
-                randomPageRequest(maxElements, cnt), categoryIds
+                LocationUtils.randomPageRequest(maxElements, cnt), categoryIds
         );
 
         return locations.stream()
@@ -107,6 +101,20 @@ public class LocationQueryAdapter implements LocationQueryPort {
 }
 
 class LocationUtils {
+
+    private static final Random RAND = ThreadLocalRandom.current();
+
+    static PageRequest randomPageRequest(
+            int pageSize, long totalElements
+    ) {
+        int total = totalElements > Integer.MAX_VALUE ?
+                Integer.MAX_VALUE : (int) totalElements;
+
+        int totalPages = Math.ceilDiv(total, pageSize);
+        int randomPage = RAND.nextInt(totalPages);
+
+        return PageRequest.of(randomPage, pageSize);
+    }
 
     static LocationResponse toRecord(Location location) {
         Long locationId = location.getId();

--- a/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
@@ -9,7 +9,7 @@ public interface AppleOAuthRepository
 
     @Query("""
             select m.id from AppleOAuth ao
-            right join ao.member m
+            inner join ao.member m
             where ao.id = :socialId
             """)
     Optional<Long> findMemberIdBySocial(String socialId);

--- a/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
@@ -9,7 +9,7 @@ public interface GoogleOAuthRepository
 
     @Query("""
             select m.id from GoogleOAuth go
-            right join go.member m
+            inner join go.member m
             where go.id = :socialId
             """)
     Optional<Long> findMemberIdBySocial(String socialId);

--- a/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
@@ -9,7 +9,7 @@ public interface KakaoOAuthRepository
 
     @Query("""
             select m.id from KakaoOAuth ko
-            right join ko.member m
+            inner join ko.member m
             where ko.id = :socialId
             """)
     Optional<Long> findMemberIdBySocial(String socialId);

--- a/src/main/java/org/leisureup/member/spi/InterestCode.java
+++ b/src/main/java/org/leisureup/member/spi/InterestCode.java
@@ -1,0 +1,7 @@
+package org.leisureup.member.spi;
+
+public record InterestCode(
+        String code
+) {
+
+}

--- a/src/main/java/org/leisureup/member/spi/MemberSpi.java
+++ b/src/main/java/org/leisureup/member/spi/MemberSpi.java
@@ -25,4 +25,9 @@ public interface MemberSpi {
             SocialType type, String socialId,
             String nickname, String email
     );
+
+    /**
+     * 사용자의 질문 응답 정보를 코드화 하여 제공
+     */
+    Optional<InterestCode> getInterest(Long memberId);
 }

--- a/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
+++ b/src/main/java/org/leisureup/member/spi/internal/MemberSpiImpl.java
@@ -12,13 +12,15 @@ import org.springframework.stereotype.*;
 public class MemberSpiImpl implements MemberSpi {
 
     private final MemberRepository memberRepo;
+    private final InterestRepository interestRepo;
     private final Map<SocialType, SocialAuth> socialAuths;
 
     public MemberSpiImpl(
-            MemberRepository memberRepo,
+            MemberRepository memberRepo, InterestRepository interestRepo,
             List<SocialAuth> socialAuths
     ) {
         this.memberRepo = memberRepo;
+        this.interestRepo = interestRepo;
         this.socialAuths = socialAuths.stream().collect(
                 Collectors.toMap(SocialAuth::getSocialAuthType, Function.identity())
         );
@@ -44,5 +46,29 @@ public class MemberSpiImpl implements MemberSpi {
         socialAuths.get(type).save(socialId, save);
 
         return save.getId();
+    }
+
+    @Override
+    public Optional<InterestCode> getInterest(Long memberId) {
+
+        Interest interest = memberId != null ?
+                interestRepo.findById(memberId).orElse(null) : null;
+
+        return Optional.ofNullable(MemberSpiUtil.toRecord(interest));
+    }
+}
+
+
+class MemberSpiUtil {
+
+    static InterestCode toRecord(Interest interest) {
+
+        InterestInfo info;
+
+        if (interest == null || (info = interest.getInfo()) == null) {
+            return null;
+        }
+
+        return new InterestCode(info.getRepresentation());
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,7 @@ spring:
       staging:
         - common-secret
         - staging-secret
+        - init-categories
       prod:
         - common-secret
         - prod-secret

--- a/src/test/java/org/leisureup/info/recommend/internal/service/DefaultScoringTest.java
+++ b/src/test/java/org/leisureup/info/recommend/internal/service/DefaultScoringTest.java
@@ -1,0 +1,46 @@
+package org.leisureup.info.recommend.internal.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.extern.slf4j.*;
+import org.junit.jupiter.api.*;
+
+@Slf4j
+class DefaultScoringTest {
+
+    final DefaultScoring defaultScoring = new DefaultScoring();
+
+    @Test
+    @DisplayName("유사도가 높을수록 더 높은 점수를 반환한다.")
+    void testScore() {
+
+        String one = "ab-ac-ad";
+
+        String test1 = "x-x-x";
+        String test2 = "a-b-c";
+        String test3 = "b-c-d";
+
+        double score1 = defaultScoring.score(one, test1);
+        double score2 = defaultScoring.score(one, test2);
+        double score3 = defaultScoring.score(one, test3);
+
+        assertThat(score1).isLessThan(score2).isLessThan(score3);
+        assertThat(score2).isLessThan(score3);
+    }
+
+    @Test
+    @DisplayName("문자열이 비교 불가능해도 점수는 반환한다.")
+    void testIncompatible() {
+        String one = "ab-ac-ad";
+
+        String[] incompatibles = {
+                "", null, "a.b?c!d", "-"
+        };
+
+        // 에러가 일어나지 않는다.
+        for (String incompatible : incompatibles) {
+            double score = defaultScoring.score(one, incompatible);
+            log.info("Score : {}", score);
+        }
+    }
+}

--- a/src/test/java/org/leisureup/info/recommend/internal/service/PrioritizingServiceTest.java
+++ b/src/test/java/org/leisureup/info/recommend/internal/service/PrioritizingServiceTest.java
@@ -1,0 +1,66 @@
+package org.leisureup.info.recommend.internal.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.*;
+import org.junit.jupiter.api.*;
+import org.leisureup.*;
+import org.leisureup.location.spi.*;
+import org.leisureup.member.spi.*;
+import org.springframework.beans.factory.annotation.*;
+
+class PrioritizingServiceTest extends IntegrationTestSupport {
+
+    private static final int TEST_SIZE = 100;
+    private static final int CODE_LEN = 10;
+    private static final Random RAND = ThreadLocalRandom.current();
+    private static final List<CategoryInfo> categories
+            = LongStream.rangeClosed(1L, TEST_SIZE)
+            .mapToObj(PrioritizingServiceTest::gen)
+            .toList();
+    @Autowired
+    PrioritizingService service;
+
+    private static CategoryInfo gen(long id) {
+        return new CategoryInfo(
+                id, String.valueOf(id), Cat.ETC,
+                randomCode(CODE_LEN)
+        );
+    }
+
+    private static String randomCode(int len) {
+        String[] codes = new String[len];
+        for (int i = 0; i < len; i++) {
+            codes[i] = randomChar();
+        }
+        return String.join("-", codes);
+    }
+
+    private static String randomChar() {
+        return String.valueOf((char) RAND.nextInt('a', 'z' + 1));
+    }
+
+    @Test
+    @DisplayName("사용자 관심에 따라 점수가 큰 순으로 정렬되어 제공된다.")
+    void prioritize() {
+
+        InterestCode memberCode = new InterestCode(
+                randomCode(2 * CODE_LEN)
+        );
+
+        int truncate = 10;
+        var resp = service.prioritize(memberCode, categories, truncate);
+
+        Comparator<Double> higherValueFirst = Comparator.reverseOrder();
+
+        assertThat(resp).isNotNull().hasSizeLessThanOrEqualTo(truncate);
+        assertThat(resp).extracting("score", Double.class)
+                .isSortedAccordingTo(higherValueFirst);
+
+        for (var prioritized : resp) {
+            assertThat(prioritized).isNotNull().hasNoNullFieldsOrProperties();
+        }
+    }
+}

--- a/src/test/java/org/leisureup/location/spi/LocationQueryPortTest.java
+++ b/src/test/java/org/leisureup/location/spi/LocationQueryPortTest.java
@@ -19,6 +19,7 @@ class LocationQueryPortTest extends IntegrationTestSupport {
     private static final Random random = new Random();
     private static final List<Long> testIds = LongStream.rangeClosed(1, 10)
             .boxed().toList();
+    private static Long exsitingCategoryId;
     @Autowired
     LocationQueryPort port;
     @Autowired
@@ -43,7 +44,8 @@ class LocationQueryPortTest extends IntegrationTestSupport {
     void setUp() {
 
         Category sampleCat = CatOther.of("sample", "1234");
-        categoryRepo.save(sampleCat);
+        exsitingCategoryId = categoryRepo.save(sampleCat)
+                .getId();
 
         List<Location> locations = testIds.stream()
                 .map(LocationQueryPortTest::genEntity)
@@ -86,5 +88,36 @@ class LocationQueryPortTest extends IntegrationTestSupport {
                         String.valueOf(missingId1), String.valueOf(missingId2)
                 );
 
+    }
+
+    @Test
+    @DisplayName("랜덤한 장소를 제공받을 수 있다.")
+    void getAnyLocations() {
+
+        int max = testIds.size() / 2;
+        List<LocationResponse> resp = port.getAnyLocations(max);
+
+        assertThat(resp).isNotNull();
+
+    }
+
+    @Test
+    @DisplayName("특정 카테고리에 속한 랜덤한 장소를 제공받을 수 있다.")
+    void getAnyLocationsOnCategory() {
+
+        int max = testIds.size() / 2;
+        List<LocationResponse> resp = port.getAnyLocationsOnCategory(max,
+                List.of(exsitingCategoryId)
+        );
+
+        assertThat(resp).isNotNull();
+
+        // 없는 카테고리 ID 가 주어지면 빈 list
+        Long nonExistingCategoryId = Long.MAX_VALUE;
+        resp = port.getAnyLocationsOnCategory(max,
+                List.of(nonExistingCategoryId)
+        );
+
+        assertThat(resp).isNotNull().isEmpty();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

사용자 질문 응답에 따른 장소 추천 기능을 추가하였습니다.

<details><summary> 간단한 내부 동작 + 주의점</summary>

### I. 사용자가 로그인 했는지 확인합니다.

만약 로그인하지 않았다면 DB 에 저장된 장소 중 랜덤하게 추첨합니다.

### II. 사용자의 질문 응답 기록을 확인합니다.

만약 응답하지 않았다면 DB 에 저장된 장소 중 랜덤하게 추첨합니다. (I. 와 동일)

### III. DB 에 저장된 모든 카테고리 중 사용자 질문 응답과 유사한 카테고리를 추려냅니다.

가장 유사한 카테고리 5 개를 추려냅니다.

### IV. 해당 카테고리에 속한 장소 중 랜덤하게 추천합니다.

추첨되는 장소는 최대 50 개이며, DB 저장 상태에 따라 0 개 일 수 있습니다.

+) DB 저장된 장소가 충분하다 가정할 때, 대부분의 확률로 50 개 장소가 추첨됩니다.

### 주의점

추첨하는 장소는 DB 에 저장된 내용을 바탕으로 이루어집니다.

때문에 서버가 초기화 상태 (대부분 새로 배포했을 시점) 에는 0 개의 장소가 추첨될 수 있습니다.

물론 실제 운영 서버에서는 배포마다 데이터를 보존시킬 예정이라 테스트용 서버에서만 위와 같은 현상이 일어날 수 있습니다.

</details>

## 💬 리뷰 요구사항 (선택)

큰 일 없으면 내일까지 merge 하겠습니다.
