### PR TITLE
Feat/weather - 기상 특보 현황 조회 기능 구성

### DIFF
--- a/src/main/java/org/leisureup/global/exception/WeatherWarningApiException.java
+++ b/src/main/java/org/leisureup/global/exception/WeatherWarningApiException.java
@@ -1,0 +1,8 @@
+package org.leisureup.global.exception;
+
+public class WeatherWarningApiException extends CustomException {
+
+    public WeatherWarningApiException(String message) {
+        super(502, message);
+    }
+}

--- a/src/main/java/org/leisureup/info/weather/controller/WeatherController.java
+++ b/src/main/java/org/leisureup/info/weather/controller/WeatherController.java
@@ -1,0 +1,23 @@
+package org.leisureup.info.weather.controller;
+
+import lombok.*;
+import org.leisureup.global.response.*;
+import org.leisureup.info.weather.service.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/weathers")
+public class WeatherController {
+
+    private final WeatherInformService weatherInformService;
+
+    @GetMapping("/warning")
+    public ApiResponse<?> getWeatherWarning() {
+
+        var resp = weatherInformService.getWeatherWarning();
+
+        return ApiResponse.success(200, resp);
+    }
+
+}

--- a/src/main/java/org/leisureup/info/weather/dto/api/ApiResponse.java
+++ b/src/main/java/org/leisureup/info/weather/dto/api/ApiResponse.java
@@ -1,0 +1,14 @@
+package org.leisureup.info.weather.dto.api;
+
+import java.util.*;
+
+public interface ApiResponse<I> {
+
+    boolean isSuccess();
+
+    boolean isEmpty();
+
+    I getSingleItem();
+
+    List<I> getAllItems();
+}

--- a/src/main/java/org/leisureup/info/weather/dto/api/GetWeatherWarningResponse.java
+++ b/src/main/java/org/leisureup/info/weather/dto/api/GetWeatherWarningResponse.java
@@ -1,0 +1,8 @@
+package org.leisureup.info.weather.dto.api;
+
+import lombok.*;
+
+@NoArgsConstructor
+public class GetWeatherWarningResponse extends WeatherWarningResponse<Warning> {
+
+}

--- a/src/main/java/org/leisureup/info/weather/dto/api/Warning.java
+++ b/src/main/java/org/leisureup/info/weather/dto/api/Warning.java
@@ -1,0 +1,28 @@
+package org.leisureup.info.weather.dto.api;
+
+import com.fasterxml.jackson.annotation.*;
+import java.time.*;
+import java.time.format.*;
+
+public record Warning(
+        @JsonProperty("other") String additionalInfo,
+        @JsonProperty("t6") String warningContent,
+        @JsonProperty("t7") String preWarningContent,
+        @JsonProperty("tmSeq") long sequence,
+
+        @JsonProperty("tmEf")
+        @JsonFormat(pattern = "yyyyMMddHHmm")
+        LocalDateTime announcedAt,
+
+        // 이건 왜인지 모르겠는데 API 응답이 string 이 아니라 number 임
+        // 그래서 @JsonFormat(pattern = "yyyyMMddHHmm") 로는 못함.
+        @JsonProperty("tmFc")
+        String activeAtRawStr
+) {
+
+    public LocalDateTime activeAt() {
+        return LocalDateTime.parse(
+                activeAtRawStr, DateTimeFormatter.ofPattern("yyyyMMddHHmm")
+        );
+    }
+}

--- a/src/main/java/org/leisureup/info/weather/dto/api/WeatherWarningResponse.java
+++ b/src/main/java/org/leisureup/info/weather/dto/api/WeatherWarningResponse.java
@@ -1,0 +1,64 @@
+package org.leisureup.info.weather.dto.api;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.info.weather.dto.api.internal.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class WeatherWarningResponse<I> implements ApiResponse<I> {
+
+    @Getter
+    private Response<I> response;
+
+    public final String getMessage() {
+        String msg = "";
+        try {
+            msg = response.header().resultMsg();
+        } catch (Exception ignored) {
+            // ignored
+        }
+
+        return msg;
+    }
+
+    @Override
+    public final boolean isSuccess() {
+        return response != null && response.isSuccess();
+    }
+
+    @Override
+    public final boolean isEmpty() {
+        if (this.isSuccess()) {
+            assert response != null;
+            Body<I> body = response.body();
+            return body == null || body.isEmpty();
+        }
+
+        return true;
+    }
+
+    @Override
+    public final I getSingleItem() {
+        if (!this.isSuccess()) {
+            throw new IllegalStateException("Response is not successful");
+        }
+
+        Body<I> body = response.body();
+        assert body != null;
+
+        return body.getSingleItem();
+    }
+
+    @Override
+    public final List<I> getAllItems() {
+        if (!this.isSuccess()) {
+            throw new IllegalStateException("Response is not successful");
+        }
+
+        Body<I> body = response.body();
+        assert body != null;
+
+        return body.getAllItems();
+    }
+}

--- a/src/main/java/org/leisureup/info/weather/dto/api/internal/Body.java
+++ b/src/main/java/org/leisureup/info/weather/dto/api/internal/Body.java
@@ -1,0 +1,38 @@
+package org.leisureup.info.weather.dto.api.internal;
+
+import java.util.*;
+
+public record Body<I>(
+        String dataType,
+        int pageNo,
+        int numOfRows,
+        int totalCount,
+        Items<I> items
+) {
+
+    public boolean isEmpty() {
+        return numOfRows == 0 || items == null || items.item().isEmpty();
+    }
+
+    public I getSingleItem() {
+        if (this.isEmpty()) {
+            throw new IllegalStateException("No item found");
+        }
+
+        List<I> itemList = items.item();
+
+        if (itemList.size() != 1) {
+            throw new IllegalStateException("Multiple items found");
+        }
+
+        return itemList.getFirst();
+    }
+
+    public List<I> getAllItems() {
+        if (this.isEmpty()) {
+            throw new IllegalStateException("No items found");
+        }
+
+        return items.item();
+    }
+}

--- a/src/main/java/org/leisureup/info/weather/dto/api/internal/Header.java
+++ b/src/main/java/org/leisureup/info/weather/dto/api/internal/Header.java
@@ -1,0 +1,14 @@
+package org.leisureup.info.weather.dto.api.internal;
+
+public record Header(
+        String resultCode,
+        String resultMsg
+) {
+
+    private static final String SUCCESS_CODE = "00";
+    private static final String SUCCESS_MSG = "NORMAL_SERVICE";
+
+    public boolean isSuccess() {
+        return SUCCESS_CODE.equals(resultCode) && SUCCESS_MSG.equals(resultMsg);
+    }
+}

--- a/src/main/java/org/leisureup/info/weather/dto/api/internal/Items.java
+++ b/src/main/java/org/leisureup/info/weather/dto/api/internal/Items.java
@@ -1,0 +1,9 @@
+package org.leisureup.info.weather.dto.api.internal;
+
+import java.util.*;
+
+public record Items<I>(
+        List<I> item
+) {
+
+}

--- a/src/main/java/org/leisureup/info/weather/dto/api/internal/Response.java
+++ b/src/main/java/org/leisureup/info/weather/dto/api/internal/Response.java
@@ -1,0 +1,11 @@
+package org.leisureup.info.weather.dto.api.internal;
+
+public record Response<I>(
+        Header header,
+        Body<I> body
+) {
+
+    public boolean isSuccess() {
+        return header != null && body != null && header.isSuccess();
+    }
+}

--- a/src/main/java/org/leisureup/info/weather/dto/response/WarningResponse.java
+++ b/src/main/java/org/leisureup/info/weather/dto/response/WarningResponse.java
@@ -1,0 +1,14 @@
+package org.leisureup.info.weather.dto.response;
+
+import java.time.*;
+
+public record WarningResponse(
+        String content,
+        String preWarnedContent,
+        LocalDateTime announcedAt,
+        LocalDateTime activatedAt,
+        long announcementSequence,
+        String additionalContent
+) {
+
+}

--- a/src/main/java/org/leisureup/info/weather/service/WeatherInformService.java
+++ b/src/main/java/org/leisureup/info/weather/service/WeatherInformService.java
@@ -1,0 +1,35 @@
+package org.leisureup.info.weather.service;
+
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.leisureup.info.weather.dto.api.*;
+import org.leisureup.info.weather.dto.response.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WeatherInformService {
+
+    private final WeatherWarningApiClient warningApiClient;
+
+    public WarningResponse getWeatherWarning() {
+        Warning info = warningApiClient.getWeatherWarning();
+        return WeatherInformUtils.toResponse(info);
+    }
+}
+
+class WeatherInformUtils {
+
+    static WarningResponse toResponse(Warning info) {
+        return new WarningResponse(
+                info.warningContent(),
+                info.preWarningContent(),
+                info.announcedAt(),
+                info.activeAt(),
+                info.sequence(),
+                info.additionalInfo()
+        );
+    }
+
+}

--- a/src/main/java/org/leisureup/info/weather/service/WeatherWarningApi.java
+++ b/src/main/java/org/leisureup/info/weather/service/WeatherWarningApi.java
@@ -1,0 +1,20 @@
+package org.leisureup.info.weather.service;
+
+import org.leisureup.info.weather.dto.api.*;
+import org.springframework.cloud.openfeign.*;
+import org.springframework.stereotype.*;
+import org.springframework.web.bind.annotation.*;
+
+@Component
+@FeignClient(
+        name = "WeatherWarningApi",
+        url = "${feign.weather.warning}"
+)
+public interface WeatherWarningApi {
+
+    @GetMapping("/getPwnStatus")
+    GetWeatherWarningResponse getWeatherWarning(
+            @RequestParam("serviceKey") String key,
+            @RequestParam("dataType") String rspType
+    );
+}

--- a/src/main/java/org/leisureup/info/weather/service/WeatherWarningApiClient.java
+++ b/src/main/java/org/leisureup/info/weather/service/WeatherWarningApiClient.java
@@ -1,0 +1,40 @@
+package org.leisureup.info.weather.service;
+
+import lombok.extern.slf4j.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.info.weather.dto.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Component
+public class WeatherWarningApiClient {
+
+    private final String key, rspType;
+    private final WeatherWarningApi weatherWarningApi;
+
+    public WeatherWarningApiClient(
+            WeatherWarningApi weatherWarningApi,
+            @Value("${weatherApi.warning.key}") String key,
+            @Value("${weatherApi.warning.type}") String rspType
+    ) {
+        this.key = key;
+        this.rspType = rspType;
+        this.weatherWarningApi = weatherWarningApi;
+    }
+
+    public Warning getWeatherWarning() {
+        var resp = weatherWarningApi.getWeatherWarning(key, rspType);
+
+        if (resp == null || !resp.isSuccess()) {
+            throw new WeatherWarningApiException("API 통신 중 문제가 발생했습니다.");
+        }
+
+        if (resp.isEmpty()) {
+            throw new WeatherWarningApiException("API 통신에는 성공했으나 content 가 비어있습니다.");
+        }
+
+        return resp.getSingleItem();
+    }
+}
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,6 +66,8 @@ feign:
   openid:
     google: https://openidconnect.googleapis.com
     kakao: https://kapi.kakao.com
+  weather:
+    warning: http://apis.data.go.kr/1360000/WthrWrnInfoService
 
 logging:
   level:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -32,6 +32,8 @@ feign:
   openid:
     google: https://openidconnect.googleapis.com
     kakao: https://kapi.kakao.com
+  weather:
+    warning: http://apis.data.go.kr/1360000/WthrWrnInfoService
 
 logging:
   #  level:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

기상특보 조회 서비스 API 를 통해 특보 현황을 조회하는 기능을 구성하였습니다.

API 관련 DTO 는 #13 `(TourApi 를 이용한 정보 fetch)` 에서 구성한 DTO 와 거의 동일합니다.

## 💬 리뷰 요구사항 (선택)

로직상 기상청 API 내용을 그대로 제공하여 별도의 test 는 구성하지 않았습니다.

+) `application-common-secret.yaml`, `application-common-test-secret.yaml` 이 변경되었으니 참고해주시면 감사하겠습니다.
