### PR TITLE
Feat/categories - 카테고리 정보 조회 기능 구성

### DIFF
--- a/src/main/java/org/leisureup/info/category/controller/CategoryController.java
+++ b/src/main/java/org/leisureup/info/category/controller/CategoryController.java
@@ -1,0 +1,21 @@
+package org.leisureup.info.category.controller;
+
+import lombok.*;
+import org.leisureup.global.response.*;
+import org.leisureup.info.category.dto.response.*;
+import org.leisureup.info.category.service.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ApiResponse<GetAllCategoriesResponse> getAllCategories() {
+        var resp = categoryService.getAllCategories();
+        return ApiResponse.success(200, resp);
+    }
+}

--- a/src/main/java/org/leisureup/info/category/controller/CategoryController.java
+++ b/src/main/java/org/leisureup/info/category/controller/CategoryController.java
@@ -1,5 +1,7 @@
 package org.leisureup.info.category.controller;
 
+import jakarta.validation.*;
+import jakarta.validation.constraints.*;
 import lombok.*;
 import org.leisureup.global.response.*;
 import org.leisureup.info.category.dto.response.*;
@@ -16,6 +18,15 @@ public class CategoryController {
     @GetMapping
     public ApiResponse<GetAllCategoriesResponse> getAllCategories() {
         var resp = categoryService.getAllCategories();
+        return ApiResponse.success(200, resp);
+    }
+
+    @GetMapping("/{categoryId}")
+    public ApiResponse<GetCategoryResponse> getCategory(
+            @Valid @Positive @NotNull
+            @PathVariable Long categoryId
+    ) {
+        var resp = categoryService.getCategory(categoryId);
         return ApiResponse.success(200, resp);
     }
 }

--- a/src/main/java/org/leisureup/info/category/dto/response/CategoryInfoResponse.java
+++ b/src/main/java/org/leisureup/info/category/dto/response/CategoryInfoResponse.java
@@ -1,0 +1,8 @@
+package org.leisureup.info.category.dto.response;
+
+public record CategoryInfoResponse(
+        Long id,
+        String name
+) {
+
+}

--- a/src/main/java/org/leisureup/info/category/dto/response/GetAllCategoriesResponse.java
+++ b/src/main/java/org/leisureup/info/category/dto/response/GetAllCategoriesResponse.java
@@ -1,0 +1,19 @@
+package org.leisureup.info.category.dto.response;
+
+import java.util.*;
+
+public record GetAllCategoriesResponse(
+        List<CategoryInfoResponse> earth,
+        List<CategoryInfoResponse> water,
+        List<CategoryInfoResponse> sky
+) {
+
+    public static GetAllCategoriesResponse of(
+            List<CategoryInfoResponse> earths,
+            List<CategoryInfoResponse> waters,
+            List<CategoryInfoResponse> skies
+    ) {
+        return new GetAllCategoriesResponse(earths, waters, skies);
+    }
+}
+

--- a/src/main/java/org/leisureup/info/category/dto/response/GetCategoryResponse.java
+++ b/src/main/java/org/leisureup/info/category/dto/response/GetCategoryResponse.java
@@ -1,0 +1,16 @@
+package org.leisureup.info.category.dto.response;
+
+public record GetCategoryResponse(
+        Long id,
+        String name,
+        String categoryCode,
+        Kind kind,
+        String thumbnailUrl,
+        String notification,
+        String description
+) {
+
+    public enum Kind {
+        EARTH, WATER, SKY, OTHER
+    }
+}

--- a/src/main/java/org/leisureup/info/category/service/CategoryService.java
+++ b/src/main/java/org/leisureup/info/category/service/CategoryService.java
@@ -1,0 +1,70 @@
+package org.leisureup.info.category.service;
+
+import java.util.*;
+import java.util.function.*;
+import lombok.*;
+import org.leisureup.info.category.dto.response.*;
+import org.leisureup.location.spi.*;
+import org.springframework.stereotype.*;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategorySpi categorySpi;
+
+    /**
+     * 땅, 물, 하늘 종류에 속한 카테고리들의 간략한 정보를 조회한다.
+     */
+    public GetAllCategoriesResponse getAllCategories() {
+
+        List<CategoryInfo> allCategories = categorySpi.getAllCategories();
+
+        var earths = CategoryServiceUtil.toResponse(
+                allCategories, CategoryServiceUtil::filterEarths
+        );
+        var waters = CategoryServiceUtil.toResponse(
+                allCategories, CategoryServiceUtil::filterWaters
+        );
+        var skies = CategoryServiceUtil.toResponse(
+                allCategories, CategoryServiceUtil::filterSkies
+        );
+
+        return GetAllCategoriesResponse.of(earths, waters, skies);
+    }
+}
+
+class CategoryServiceUtil {
+
+    private static boolean filter(
+            CategoryInfo cat,
+            Cat categoryType
+    ) {
+        return cat.category().equals(categoryType);
+    }
+
+    static boolean filterEarths(CategoryInfo cat) {
+        return filter(cat, Cat.EARTH);
+    }
+
+    static boolean filterWaters(CategoryInfo cat) {
+        return filter(cat, Cat.WATER);
+    }
+
+    static boolean filterSkies(CategoryInfo cat) {
+        return filter(cat, Cat.SKY);
+    }
+
+    private static CategoryInfoResponse toResponse(CategoryInfo cat) {
+        return new CategoryInfoResponse(cat.id(), cat.name());
+    }
+
+    static List<CategoryInfoResponse> toResponse(
+            List<CategoryInfo> cats, Predicate<CategoryInfo> filter
+    ) {
+        return cats.stream()
+                .filter(filter)
+                .map(CategoryServiceUtil::toResponse)
+                .toList();
+    }
+}

--- a/src/main/java/org/leisureup/info/category/service/CategoryService.java
+++ b/src/main/java/org/leisureup/info/category/service/CategoryService.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.*;
 import lombok.*;
 import org.leisureup.info.category.dto.response.*;
+import org.leisureup.info.category.dto.response.GetCategoryResponse.*;
 import org.leisureup.location.spi.*;
 import org.springframework.stereotype.*;
 
@@ -31,6 +32,16 @@ public class CategoryService {
         );
 
         return GetAllCategoriesResponse.of(earths, waters, skies);
+    }
+
+    /**
+     * 한 카테고리의 자세한 정보를 조회한다.
+     */
+    public GetCategoryResponse getCategory(Long categoryId) {
+
+        var resp = categorySpi.getCategoryDetail(categoryId);
+
+        return CategoryServiceUtil.toResponse(resp);
     }
 }
 
@@ -66,5 +77,34 @@ class CategoryServiceUtil {
                 .filter(filter)
                 .map(CategoryServiceUtil::toResponse)
                 .toList();
+    }
+
+    static GetCategoryResponse toResponse(DetailedCategoryInfo detailedInfo) {
+        Long id = detailedInfo.id();
+        String name = detailedInfo.name();
+        String code = detailedInfo.categoryCode();
+        Kind kind = resolveKind(detailedInfo.category());
+        String thumbnailUrl = detailedInfo.thumbnailUrl();
+        String notification = detailedInfo.notification();
+        String description = detailedInfo.description();
+
+        return new GetCategoryResponse(
+                id, emptyIfNull(name), emptyIfNull(code),
+                kind, emptyIfNull(thumbnailUrl),
+                emptyIfNull(notification), emptyIfNull(description)
+        );
+    }
+
+    private static Kind resolveKind(Cat category) {
+        return switch (category) {
+            case EARTH -> Kind.EARTH;
+            case WATER -> Kind.WATER;
+            case SKY -> Kind.SKY;
+            default -> Kind.OTHER;
+        };
+    }
+
+    private static String emptyIfNull(String s) {
+        return s == null ? "" : s;
     }
 }

--- a/src/main/java/org/leisureup/info/recommend/controller/RecommendController.java
+++ b/src/main/java/org/leisureup/info/recommend/controller/RecommendController.java
@@ -1,11 +1,11 @@
-package org.leisureup.info.recommend.internal.controller;
+package org.leisureup.info.recommend.controller;
 
 import java.util.*;
 import lombok.*;
 import org.leisureup.global.*;
 import org.leisureup.global.response.*;
-import org.leisureup.info.recommend.internal.dto.response.*;
-import org.leisureup.info.recommend.internal.service.*;
+import org.leisureup.info.recommend.dto.response.*;
+import org.leisureup.info.recommend.service.*;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/org/leisureup/info/recommend/dto/PrioritizedCategoryInfo.java
+++ b/src/main/java/org/leisureup/info/recommend/dto/PrioritizedCategoryInfo.java
@@ -1,4 +1,4 @@
-package org.leisureup.info.recommend.internal.dto;
+package org.leisureup.info.recommend.dto;
 
 import org.springframework.lang.*;
 

--- a/src/main/java/org/leisureup/info/recommend/dto/response/LocationInfo.java
+++ b/src/main/java/org/leisureup/info/recommend/dto/response/LocationInfo.java
@@ -1,4 +1,4 @@
-package org.leisureup.info.recommend.internal.dto.response;
+package org.leisureup.info.recommend.dto.response;
 
 public record LocationInfo(
         Long id,

--- a/src/main/java/org/leisureup/info/recommend/service/DefaultScoring.java
+++ b/src/main/java/org/leisureup/info/recommend/service/DefaultScoring.java
@@ -1,4 +1,4 @@
-package org.leisureup.info.recommend.internal.service;
+package org.leisureup.info.recommend.service;
 
 import lombok.extern.slf4j.*;
 

--- a/src/main/java/org/leisureup/info/recommend/service/PrioritizingService.java
+++ b/src/main/java/org/leisureup/info/recommend/service/PrioritizingService.java
@@ -1,9 +1,9 @@
-package org.leisureup.info.recommend.internal.service;
+package org.leisureup.info.recommend.service;
 
 import java.util.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
-import org.leisureup.info.recommend.internal.dto.*;
+import org.leisureup.info.recommend.dto.*;
 import org.leisureup.location.spi.*;
 import org.leisureup.member.spi.*;
 import org.springframework.stereotype.*;

--- a/src/main/java/org/leisureup/info/recommend/service/RecommendService.java
+++ b/src/main/java/org/leisureup/info/recommend/service/RecommendService.java
@@ -1,11 +1,11 @@
-package org.leisureup.info.recommend.internal.service;
+package org.leisureup.info.recommend.service;
 
 import java.util.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
-import org.leisureup.info.recommend.internal.dto.*;
-import org.leisureup.info.recommend.internal.dto.response.*;
-import org.leisureup.info.recommend.internal.dto.response.LocationInfo.*;
+import org.leisureup.info.recommend.dto.*;
+import org.leisureup.info.recommend.dto.response.*;
+import org.leisureup.info.recommend.dto.response.LocationInfo.*;
 import org.leisureup.location.spi.*;
 import org.leisureup.member.spi.*;
 import org.springframework.stereotype.*;

--- a/src/main/java/org/leisureup/info/recommend/service/Scoring.java
+++ b/src/main/java/org/leisureup/info/recommend/service/Scoring.java
@@ -1,4 +1,4 @@
-package org.leisureup.info.recommend.internal.service;
+package org.leisureup.info.recommend.service;
 
 /**
  * 두 문자열간 유사성 점수를 제공하는 계약

--- a/src/main/java/org/leisureup/info/recommend/service/ScoringConfig.java
+++ b/src/main/java/org/leisureup/info/recommend/service/ScoringConfig.java
@@ -1,4 +1,4 @@
-package org.leisureup.info.recommend.internal.service;
+package org.leisureup.info.recommend.service;
 
 import org.springframework.context.annotation.*;
 

--- a/src/main/java/org/leisureup/location/internal/domain/AdditionalCategoryInfo.java
+++ b/src/main/java/org/leisureup/location/internal/domain/AdditionalCategoryInfo.java
@@ -1,0 +1,44 @@
+package org.leisureup.location.internal.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdditionalCategoryInfo {
+
+    @Column(length = 1000)
+    private String thumbnailUrl;
+
+    @Column(length = 1000)
+    private String notification;
+
+    @Lob
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    private SuitableSeason season = SuitableSeason.ANY;
+
+    public static AdditionalCategoryInfo of(
+            String thumbnailUrl, String notification,
+            String description, SuitableSeason season
+    ) {
+        return new AdditionalCategoryInfo(
+                thumbnailUrl, notification, description, season
+        );
+    }
+
+    public static AdditionalCategoryInfo of(AdditionalCategoryInfo given) {
+        return new AdditionalCategoryInfo(
+                given.getThumbnailUrl(), given.getNotification(),
+                given.getDescription(), given.getSeason()
+        );
+    }
+
+    public enum SuitableSeason {
+        SPRING, SUMMER, AUTUMN, WINTER, ANY
+    }
+}

--- a/src/main/java/org/leisureup/location/internal/domain/CatEarth.java
+++ b/src/main/java/org/leisureup/location/internal/domain/CatEarth.java
@@ -22,12 +22,26 @@ public class CatEarth extends Category {
         super(name, categoryCode, recommendationCode);
     }
 
+    private CatEarth(
+            String name, String categoryCode, String recommendationCode,
+            AdditionalCategoryInfo additionalInfo
+    ) {
+        super(name, categoryCode, recommendationCode, additionalInfo);
+    }
+
     public static CatEarth of(String name, String code) {
         return new CatEarth(name, code);
     }
 
     public static CatEarth of(String name, String code, String recommendationCode) {
         return new CatEarth(name, code, recommendationCode);
+    }
+
+    public static CatEarth of(
+            String name, String categoryCode, String recommendationCode,
+            AdditionalCategoryInfo additionalInfo
+    ) {
+        return new CatEarth(name, categoryCode, recommendationCode, additionalInfo);
     }
 
     @Override

--- a/src/main/java/org/leisureup/location/internal/domain/CatOther.java
+++ b/src/main/java/org/leisureup/location/internal/domain/CatOther.java
@@ -22,12 +22,26 @@ public class CatOther extends Category {
         super(name, categoryCode, recommendationCode);
     }
 
+    private CatOther(
+            String name, String categoryCode, String recommendationCode,
+            AdditionalCategoryInfo additionalInfo
+    ) {
+        super(name, categoryCode, recommendationCode, additionalInfo);
+    }
+
     public static CatOther of(String name, String code) {
         return new CatOther(name, code);
     }
 
     public static CatOther of(String name, String code, String recommendationCode) {
         return new CatOther(name, code, recommendationCode);
+    }
+
+    public static CatOther of(
+            String name, String code, String recommendationCode,
+            AdditionalCategoryInfo additionalInfo
+    ) {
+        return new CatOther(name, code, recommendationCode, additionalInfo);
     }
 
     @Override

--- a/src/main/java/org/leisureup/location/internal/domain/CatSky.java
+++ b/src/main/java/org/leisureup/location/internal/domain/CatSky.java
@@ -22,12 +22,26 @@ public class CatSky extends Category {
         super(name, categoryCode, recommendationCode);
     }
 
+    private CatSky(
+            String name, String categoryCode, String recommendationCode,
+            AdditionalCategoryInfo additionalInfo
+    ) {
+        super(name, categoryCode, recommendationCode, additionalInfo);
+    }
+
     public static CatSky of(String name, String categoryCode) {
         return new CatSky(name, categoryCode);
     }
 
     public static CatSky of(String name, String categoryCode, String recommendationCode) {
         return new CatSky(name, categoryCode, recommendationCode);
+    }
+
+    public static CatSky of(
+            String name, String categoryCode, String recommendationCode,
+            AdditionalCategoryInfo additionalInfo
+    ) {
+        return new CatSky(name, categoryCode, recommendationCode, additionalInfo);
     }
 
     @Override

--- a/src/main/java/org/leisureup/location/internal/domain/CatWater.java
+++ b/src/main/java/org/leisureup/location/internal/domain/CatWater.java
@@ -22,12 +22,26 @@ public class CatWater extends Category {
         super(name, categoryCode, recommendationCode);
     }
 
+    private CatWater(
+            String name, String categoryCode, String recommendationCode,
+            AdditionalCategoryInfo additionalInfo
+    ) {
+        super(name, categoryCode, recommendationCode, additionalInfo);
+    }
+
     public static CatWater of(String name, String categoryCode) {
         return new CatWater(name, categoryCode);
     }
 
     public static CatWater of(String name, String categoryCode, String recommendCode) {
         return new CatWater(name, categoryCode, recommendCode);
+    }
+
+    public static CatWater of(
+            String name, String categoryCode, String recommendationCode,
+            AdditionalCategoryInfo additionalInfo
+    ) {
+        return new CatWater(name, categoryCode, recommendationCode, additionalInfo);
     }
 
     @Override

--- a/src/main/java/org/leisureup/location/internal/domain/Category.java
+++ b/src/main/java/org/leisureup/location/internal/domain/Category.java
@@ -34,6 +34,9 @@ public abstract class Category {
     @Embedded
     private CategoryRecommend recommendation;
 
+    @Embedded
+    private AdditionalCategoryInfo additionalInfo;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -52,6 +55,14 @@ public abstract class Category {
         this.name = name;
         this.categoryCode = categoryCode;
         this.recommendation = CategoryRecommend.of(recommendationCode);
+    }
+
+    protected Category(
+            String name, String categoryCode, String recommendationCode,
+            AdditionalCategoryInfo additionalInfo
+    ) {
+        this(name, categoryCode, recommendationCode);
+        this.additionalInfo = additionalInfo;
     }
 
     public abstract String getCategoryType();

--- a/src/main/java/org/leisureup/location/internal/repository/init/Earth.java
+++ b/src/main/java/org/leisureup/location/internal/repository/init/Earth.java
@@ -3,6 +3,7 @@ package org.leisureup.location.internal.repository.init;
 import static org.leisureup.location.internal.repository.init.Utils.*;
 
 import lombok.*;
+import org.leisureup.location.internal.domain.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -65,4 +66,8 @@ public enum Earth {
     );
 
     final String name, code, recommendCode;
+
+    public CatEarth toEntity() {
+        return CatEarth.of(name, code, recommendCode);
+    }
 }

--- a/src/main/java/org/leisureup/location/internal/repository/init/InitializeCategory.java
+++ b/src/main/java/org/leisureup/location/internal/repository/init/InitializeCategory.java
@@ -49,19 +49,19 @@ class CategoryInitializer {
         List<Category> all = new ArrayList<>(100);
 
         List<CatEarth> earths = Arrays.stream(Earth.values())
-                .map(e -> CatEarth.of(e.getName(), e.getCode(), e.getRecommendCode()))
+                .map(Earth::toEntity)
                 .toList();
 
         List<CatWater> waters = Arrays.stream(Water.values())
-                .map(e -> CatWater.of(e.getName(), e.getCode(), e.getRecommendCode()))
+                .map(Water::toEntity)
                 .toList();
 
         List<CatSky> skies = Arrays.stream(Sky.values())
-                .map(e -> CatSky.of(e.getName(), e.getCode(), e.getRecommendCode()))
+                .map(Sky::toEntity)
                 .toList();
 
         List<CatOther> others = Arrays.stream(Other.values())
-                .map(e -> CatOther.of(e.getName(), e.getCode(), e.getRecommendCode()))
+                .map(Other::toEntity)
                 .toList();
 
         all.addAll(earths);

--- a/src/main/java/org/leisureup/location/internal/repository/init/Other.java
+++ b/src/main/java/org/leisureup/location/internal/repository/init/Other.java
@@ -1,6 +1,7 @@
 package org.leisureup.location.internal.repository.init;
 
 import lombok.*;
+import org.leisureup.location.internal.domain.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -14,4 +15,7 @@ public enum Other {
 
     final String name, code, recommendCode;
 
+    public CatOther toEntity() {
+        return CatOther.of(name, code, recommendCode);
+    }
 }

--- a/src/main/java/org/leisureup/location/internal/repository/init/Sky.java
+++ b/src/main/java/org/leisureup/location/internal/repository/init/Sky.java
@@ -3,6 +3,7 @@ package org.leisureup.location.internal.repository.init;
 import static org.leisureup.location.internal.repository.init.Utils.*;
 
 import lombok.*;
+import org.leisureup.location.internal.domain.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -24,4 +25,7 @@ public enum Sky {
 
     final String name, code, recommendCode;
 
+    public CatSky toEntity() {
+        return CatSky.of(name, code, recommendCode);
+    }
 }

--- a/src/main/java/org/leisureup/location/internal/repository/init/Water.java
+++ b/src/main/java/org/leisureup/location/internal/repository/init/Water.java
@@ -3,6 +3,7 @@ package org.leisureup.location.internal.repository.init;
 import static org.leisureup.location.internal.repository.init.Utils.*;
 
 import lombok.*;
+import org.leisureup.location.internal.domain.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -36,4 +37,7 @@ public enum Water {
 
     final String name, code, recommendCode;
 
+    public CatWater toEntity() {
+        return CatWater.of(name, code, recommendCode);
+    }
 }

--- a/src/main/java/org/leisureup/location/spi/CategorySpi.java
+++ b/src/main/java/org/leisureup/location/spi/CategorySpi.java
@@ -9,4 +9,8 @@ public interface CategorySpi {
      */
     List<CategoryInfo> getAllCategories();
 
+    /**
+     * 특정 카테고리의 세부 정보를 조회
+     */
+    DetailedCategoryInfo getCategoryDetail(Long categoryId);
 }

--- a/src/main/java/org/leisureup/location/spi/DetailedCategoryInfo.java
+++ b/src/main/java/org/leisureup/location/spi/DetailedCategoryInfo.java
@@ -1,0 +1,14 @@
+package org.leisureup.location.spi;
+
+public record DetailedCategoryInfo(
+        Long id,
+        String categoryCode,
+        String name,
+        Cat category,
+        String thumbnailUrl,
+        String notification,
+        String description,
+        String recommendingCode
+) {
+
+}

--- a/src/main/java/org/leisureup/location/spi/internal/CategorySpiImpl.java
+++ b/src/main/java/org/leisureup/location/spi/internal/CategorySpiImpl.java
@@ -2,6 +2,7 @@ package org.leisureup.location.spi.internal;
 
 import java.util.*;
 import lombok.*;
+import org.leisureup.global.exception.*;
 import org.leisureup.location.internal.domain.*;
 import org.leisureup.location.internal.repository.*;
 import org.leisureup.location.spi.*;
@@ -18,6 +19,15 @@ public class CategorySpiImpl implements CategorySpi {
         return categoryRepo.findAll().stream()
                 .map(CategorySpiUtil::toRecord)
                 .toList();
+    }
+
+    @Override
+    public DetailedCategoryInfo getCategoryDetail(Long categoryId) {
+
+        Category find = categoryRepo.findById(categoryId)
+                .orElseThrow(() -> new NotFound("Category not found"));
+
+        return CategorySpiUtil.toDetailedRecord(find);
     }
 }
 
@@ -42,12 +52,42 @@ class CategorySpiUtil {
         return new CategoryInfo(id, name, cat, recommendCode);
     }
 
-    static Cat resolveCategoryType(Category category) {
+    static DetailedCategoryInfo toDetailedRecord(Category category) {
+        CategoryInfo basicInfo = toRecord(category);
+
+        Long id = basicInfo.id();
+        String name = basicInfo.name();
+        Cat cat = basicInfo.category();
+        String recommendCode = basicInfo.recommendingCode();
+
+        String categoryCode = category.getCategoryCode();
+
+        String thumbnail = "", notification = "", description = "";
+        AdditionalCategoryInfo additionalInfo = category.getAdditionalInfo();
+
+        if (additionalInfo != null) {
+            thumbnail = additionalInfo.getThumbnailUrl();
+            notification = additionalInfo.getNotification();
+            description = additionalInfo.getDescription();
+        }
+
+        return new DetailedCategoryInfo(
+                id, emptyIfNull(categoryCode), name, cat,
+                emptyIfNull(thumbnail), emptyIfNull(notification),
+                emptyIfNull(description), recommendCode
+        );
+    }
+
+    private static Cat resolveCategoryType(Category category) {
         return switch (category.getCategoryType()) {
             case "EARTH" -> Cat.EARTH;
             case "WATER" -> Cat.WATER;
             case "SKY" -> Cat.SKY;
             default -> Cat.ETC;
         };
+    }
+
+    private static String emptyIfNull(String s) {
+        return s == null ? "" : s;
     }
 }

--- a/src/test/java/org/leisureup/info/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/leisureup/info/category/service/CategoryServiceTest.java
@@ -1,0 +1,67 @@
+package org.leisureup.info.category.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import org.junit.jupiter.api.*;
+import org.leisureup.*;
+import org.leisureup.location.spi.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.test.context.bean.override.mockito.*;
+
+class CategoryServiceTest extends IntegrationTestSupport {
+
+    private static final int TOTAL_NUM = 5 * 3;
+    private static final int NUM_EARTHS = TOTAL_NUM / 3,
+            NUM_WATERS = TOTAL_NUM / 3, NUM_SKIES = TOTAL_NUM / 3;
+    @Autowired
+    CategoryService service;
+    @MockitoBean
+    CategorySpi categorySpi;
+
+    private static CategoryInfo gen(Long id, Cat cat) {
+        String name = String.format("Cat:%d", id);
+        return new CategoryInfo(id, name, cat, name);
+    }
+
+    @BeforeEach
+    void setUp() {
+        List<CategoryInfo> infos = new ArrayList<>(TOTAL_NUM);
+
+        long id = 1;
+        for (int i = 0; i < NUM_EARTHS; i++) {
+            infos.add(gen(id, Cat.EARTH));
+        }
+        for (int i = 0; i < NUM_WATERS; i++) {
+            infos.add(gen(id, Cat.WATER));
+        }
+        for (int i = 0; i < NUM_SKIES; i++) {
+            infos.add(gen(id, Cat.SKY));
+        }
+
+        when(categorySpi.getAllCategories()).thenReturn(infos);
+    }
+
+    @Test
+    @DisplayName("모든 카테고리 정보를 조회할 수 있다.")
+    void getAllCategories() {
+
+        var resp = service.getAllCategories();
+
+        assertThat(resp).isNotNull().hasNoNullFieldsOrProperties();
+        var earths = resp.earth();
+        var waters = resp.water();
+        var skies = resp.sky();
+
+        assertThat(earths).hasSize(NUM_EARTHS);
+        assertThat(waters).hasSize(NUM_WATERS);
+        assertThat(skies).hasSize(NUM_SKIES);
+
+        for (var list : new List[]{earths, waters, skies}) {
+            for (var info : list) {
+                assertThat(info).isNotNull().hasNoNullFieldsOrProperties();
+            }
+        }
+    }
+}

--- a/src/test/java/org/leisureup/info/recommend/service/DefaultScoringTest.java
+++ b/src/test/java/org/leisureup/info/recommend/service/DefaultScoringTest.java
@@ -1,4 +1,4 @@
-package org.leisureup.info.recommend.internal.service;
+package org.leisureup.info.recommend.service;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/org/leisureup/info/recommend/service/PrioritizingServiceTest.java
+++ b/src/test/java/org/leisureup/info/recommend/service/PrioritizingServiceTest.java
@@ -1,4 +1,4 @@
-package org.leisureup.info.recommend.internal.service;
+package org.leisureup.info.recommend.service;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/org/leisureup/location/spi/CategorySpiTest.java
+++ b/src/test/java/org/leisureup/location/spi/CategorySpiTest.java
@@ -6,6 +6,7 @@ import java.util.*;
 import lombok.extern.slf4j.*;
 import org.junit.jupiter.api.*;
 import org.leisureup.*;
+import org.leisureup.global.exception.*;
 import org.leisureup.location.internal.domain.*;
 import org.leisureup.location.internal.repository.*;
 import org.springframework.beans.factory.annotation.*;
@@ -19,6 +20,9 @@ class CategorySpiTest extends IntegrationTestSupport {
     @Autowired
     CategoryRepository categoryRepo;
 
+    private static final Long nonExistingId = Long.MAX_VALUE;
+    private static Long id1, id2, id3;
+
     @BeforeEach
     void setUp() {
         CatEarth sample1 = CatEarth.of("1", "1");
@@ -26,6 +30,10 @@ class CategorySpiTest extends IntegrationTestSupport {
         CatOther sample3 = CatOther.of("3", "3", "cd");
 
         categoryRepo.saveAll(List.of(sample1, sample2, sample3));
+
+        id1 = sample1.getId();
+        id2 = sample2.getId();
+        id3 = sample3.getId();
     }
 
     @AfterEach
@@ -45,5 +53,24 @@ class CategorySpiTest extends IntegrationTestSupport {
         for (var one : resp) {
             assertThat(one).hasNoNullFieldsOrProperties();
         }
+    }
+
+    @Test
+    @DisplayName("특정 카테고리 정보를 조회할 수 있다.")
+    void getCategoryDetail() {
+
+        for (Long id : new Long[]{id1, id2, id3}) {
+            var resp = categorySpi.getCategoryDetail(id);
+
+            assertThat(resp).isNotNull().hasNoNullFieldsOrProperties();
+        }
+
+    }
+
+    @Test
+    @DisplayName("카테고리가 없을땐 에러가 발생한다.")
+    void testNotFound() {
+        assertThatThrownBy(() -> categorySpi.getCategoryDetail(nonExistingId))
+                .isInstanceOf(NotFound.class);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

메인 페이지에서 카테고리 조회와 관련된 기능을 구성했습니다.

1. 전체 카테고리 조회 기능을 구성했습니다. `(/categories)`
2. 어느 한 카테고리 세부 정보 조회 기능을 구성했습니다. `(/categories/{categoryId})`

## 💬 리뷰 요구사항 (선택)

정보 조회는 `CategorySpi` 의 기능을 그대로 사용하여 `CategoryService` 와 관련된 테스트 코드는 작성하지 않았습니다.
