### PR TITLE
Test/async - OpenFeign 비동기 관련 논의를 위한 PR

### DIFF
--- a/src/main/java/org/leisureup/test/TestAsyncService.java
+++ b/src/main/java/org/leisureup/test/TestAsyncService.java
@@ -1,0 +1,36 @@
+package org.leisureup.test;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.*;
+import lombok.*;
+import org.leisureup.test.internal.api.*;
+import org.springframework.stereotype.*;
+
+@Service
+@RequiredArgsConstructor
+public class TestAsyncService {
+
+    private final GoogleOidcWellKnownAsyncWrapper asyncWrapper;
+
+    public List<GoogleWellKnownResp> testSync(int testSize) {
+        return IntStream.range(0, testSize)
+                .mapToObj(i -> asyncWrapper.onSync())
+                .toList();
+    }
+
+    public List<GoogleWellKnownResp> testAsync(int testSize) {
+
+        // 별도의 스레드에서 asyncWrapper.onAsync() 가 수행 (하도록 q 넣음)
+        List<CompletableFuture<GoogleWellKnownResp>> completableFutures
+                = IntStream.range(0, testSize)
+                .mapToObj(i -> asyncWrapper.onAsync())
+                .toList();
+
+        // 모든 작업이 끝날때까지 기다림 (join)
+        // 수행한 내역의 결과를 반환
+        return completableFutures.stream()
+                .map(CompletableFuture::join)   // 만약 수행 중 에러가 발생했었면 여기서 해당 에러가 다시 thrown
+                .toList();
+    }
+}

--- a/src/main/java/org/leisureup/test/TestController.java
+++ b/src/main/java/org/leisureup/test/TestController.java
@@ -1,0 +1,31 @@
+package org.leisureup.test;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.global.response.*;
+import org.leisureup.test.internal.*;
+import org.leisureup.test.internal.api.*;
+import org.springframework.web.bind.annotation.*;
+
+@EstimateTime
+@RestController
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class TestController {
+
+    private final TestAsyncService testAsyncService;
+
+    @GetMapping("/sync")
+    public ApiResponse<List<GoogleWellKnownResp>> testSync(
+            @RequestParam(defaultValue = "25") int testSize
+    ) {
+        return ApiResponse.success(200, testAsyncService.testSync(testSize));
+    }
+
+    @GetMapping("/async")
+    public ApiResponse<List<GoogleWellKnownResp>> testAsync(
+            @RequestParam(defaultValue = "25") int testSize
+    ) {
+        return ApiResponse.success(200, testAsyncService.testAsync(testSize));
+    }
+}

--- a/src/main/java/org/leisureup/test/internal/AsyncConfig.java
+++ b/src/main/java/org/leisureup/test/internal/AsyncConfig.java
@@ -1,0 +1,22 @@
+package org.leisureup.test.internal;
+
+import java.util.concurrent.*;
+import org.springframework.context.annotation.*;
+import org.springframework.scheduling.annotation.*;
+import org.springframework.scheduling.concurrent.*;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean
+    public Executor asyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(20);
+        executor.setMaxPoolSize(50);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("Async-Executor:");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/org/leisureup/test/internal/EstimateTime.java
+++ b/src/main/java/org/leisureup/test/internal/EstimateTime.java
@@ -1,0 +1,9 @@
+package org.leisureup.test.internal;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EstimateTime {
+
+}

--- a/src/main/java/org/leisureup/test/internal/ExecutionAspect.java
+++ b/src/main/java/org/leisureup/test/internal/ExecutionAspect.java
@@ -1,0 +1,36 @@
+package org.leisureup.test.internal;
+
+import lombok.extern.slf4j.*;
+import org.aspectj.lang.*;
+import org.aspectj.lang.annotation.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Aspect
+@Component
+public class ExecutionAspect {
+
+    private static String format(String signature, long start, long end) {
+        return String.format("Execution time on [%30S]\t: %,d ms", signature, (end - start));
+    }
+
+    @Pointcut("@within(EstimateTime) || @annotation(EstimateTime)")
+    public void estimateTimePointCut() {
+
+    }
+
+    @Around("estimateTimePointCut()")
+    public Object estimateExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        String signature = joinPoint.getSignature().toShortString();
+
+        long start = System.currentTimeMillis();
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            long end = System.currentTimeMillis();
+            log.info(format(signature, start, end));
+        }
+    }
+}

--- a/src/main/java/org/leisureup/test/internal/api/GoogleOidcWellKnown.java
+++ b/src/main/java/org/leisureup/test/internal/api/GoogleOidcWellKnown.java
@@ -1,0 +1,14 @@
+package org.leisureup.test.internal.api;
+
+import org.springframework.cloud.openfeign.*;
+import org.springframework.web.bind.annotation.*;
+
+@FeignClient(
+        name = "GoogleOidcWellKnown",
+        url = "https://accounts.google.com"
+)
+public interface GoogleOidcWellKnown {
+
+    @GetMapping("/.well-known/openid-configuration")
+    GoogleWellKnownResp get();
+}

--- a/src/main/java/org/leisureup/test/internal/api/GoogleOidcWellKnownAsyncWrapper.java
+++ b/src/main/java/org/leisureup/test/internal/api/GoogleOidcWellKnownAsyncWrapper.java
@@ -1,0 +1,23 @@
+package org.leisureup.test.internal.api;
+
+import java.util.concurrent.*;
+import lombok.*;
+import org.springframework.scheduling.annotation.*;
+import org.springframework.stereotype.*;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleOidcWellKnownAsyncWrapper {
+
+    private final GoogleOidcWellKnown testClient;
+
+    public GoogleWellKnownResp onSync() {
+        return testClient.get();
+    }
+
+    @Async
+    public CompletableFuture<GoogleWellKnownResp> onAsync() {
+        // testClient.get() 아니어도 딱히 상관 X
+        return CompletableFuture.completedFuture(onSync());
+    }
+}

--- a/src/main/java/org/leisureup/test/internal/api/GoogleWellKnownResp.java
+++ b/src/main/java/org/leisureup/test/internal/api/GoogleWellKnownResp.java
@@ -1,0 +1,17 @@
+package org.leisureup.test.internal.api;
+
+import com.fasterxml.jackson.annotation.*;
+
+// 테스트용이니까 없는건 그냥 안넣도록
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleWellKnownResp(
+        String issuer
+) {
+
+    private static final String GOOD = "https://accounts.google.com";
+
+    public boolean isValid() {
+        return GOOD.equals(issuer);
+    }
+
+}


### PR DESCRIPTION
관련 Reference 를 조사한 결과 크게 2 가지 솔루션이 있는 것 같습니다.

---

## A. `WebClient (Spring WebFlux)` : 비동기 non-blocking

비동기 API 호출이 필요한 부분에 `WebClient` 를 사용할 수 있습니다.
즉, 현재 구현된 `FeignClient` 는 내비두되, 레저 종류 필터링 기능에서만 `WebClient` 를 사용하는 방식입니다.

해당 방식의 장단점은 아래와 같습니다.

### 장점

- 새로운 기술 시도 `(WebFlux)`
- non-blocking 이므로 openFeign 보다는 빠름
- 추후 다른 `FeignClient` 에도 접목시켜볼 수 있음

### 단점

- 새로운 기술 시도로 작업이 얼마나 걸릴지 가늠되지 않음
- openFeign 보다는 빠르지만 얼마나 유의미할지 지금으로선 알 수 없음
- non-blocking 이 더 좋긴 하지만, 현재 서비스에서 non-blocking 으로 얻는 이점이 커 보이지 않음.
    (현재 서비스는 `API 호출 --> 응답 정제 --> client 에게 제공` 이 대부분임. 즉, `API 호출 --> 응답 정제` 과정 사이에 뭔가 진행해야할 작업이 없음.)

---

## B. `FeignClient` + `@Async (Spring Boot)` : 비동기 non-blocking + 여러 sync blocking taskers

반면 `FeignClient` 를 그대로 사용하되, Spring Boot 의 `@Async` 를 얹혀 사용할 수도 있습니다.
즉, `FeignClient` 를 감싸 비동기 수행을 처리하는 클래스를 구성하는 방식입니다. 

해당 방식은 현재 서비스 구조에서도 시험 가능하므로, 간략한 코드를 만들어 이번 PR 로 올려봤습니다.

핵심 코드는 다음과 같습니다.

- `GoogleOidcWellKnown.java` : 테스트용 임의의 `FeignClient` 입니다.

```java
@FeignClient(
        name = "GoogleOidcWellKnown",
        url = "https://accounts.google.com"
)
public interface GoogleOidcWellKnown {

    @GetMapping("/.well-known/openid-configuration")
    GoogleWellKnownResp get();
}
```

- `GoogleOidcWellKnownAsyncWrapper.java` : `FeignClient` 를 감싸 비동기 수행 기능을 제공하는 클래스

```java
@Component
@RequiredArgsConstructor
public class GoogleOidcWellKnownAsyncWrapper {

    private final GoogleOidcWellKnown testClient;

    public GoogleWellKnownResp onSync() {
        return testClient.get();
    }

    @Async
    public CompletableFuture<GoogleWellKnownResp> onAsync() {
        // testClient.get() 아니어도 딱히 상관 X
        return CompletableFuture.completedFuture(onSync());
    }
}
```

`onSync()` 는 동기, `onAsync()` 는 비동기 수행을 진행하는 메서드입니다.

위 메서드들에 대해 테스트 `(25 번 수행)` 를 진행한 결과는 아래와 같습니다.

- 동기 수행 : `onSync()` -- 약 `1,960 ms`

<img width="484" alt="스크린샷 2025-07-03 16 21 31" src="https://github.com/user-attachments/assets/0cf069d4-151d-48a8-b662-fd4520b4d888" />


- 비동기 수행 : `onAsync()` -- 약 `372 ms`

<img width="484" alt="스크린샷 2025-07-03 16 21 46" src="https://github.com/user-attachments/assets/da5fbf5b-3b84-400a-9c74-002fc388f028" />


- log

```log
2025-07-03T16:22:04.772KST  INFO 38293 --- [LeisureUp-BE] [mcat-handler-10] o.l.test.internal.ExecutionAspect        : Execution time on [   TESTCONTROLLER.TESTSYNC(..)]	: 1,834 ms
2025-07-03T16:22:07.144KST  INFO 38293 --- [LeisureUp-BE] [mcat-handler-12] o.l.test.internal.ExecutionAspect        : Execution time on [  TESTCONTROLLER.TESTASYNC(..)]	: 271 ms
```

위 방식에 대한 장단점은 아래와 같습니다.

### 장점

- 비교적 구현 난이도가 낮아보임
- "비동기 수행 wrapper" 만 구성하면 되므로, 추후 확장 또는 수정에 용이해 보임

### 단점

- OpenFeign 의 한계상 tasker 가 non-blocking 할 수 없음.
- 서버 부하를 고려해 알맞은 스레드 풀 사이즈를 구성해야 함. (사실 이건 `WebFlux` 도 비슷)

---

승진님은 두 방식 중 어떤게 좋다고 생각하시나요?

---

### `B` 방식과 관련된 reference
- [[클라우드 기반 보안 실습 플랫폼 개발기] Spring-Boot 에서 OpenFeign 과 CompletableFuture 를 이용한 비동기적 HTTP 요청](https://wonit.tistory.com/594)
- [Feign client Async call](https://tnfhrnsss.github.io/docs/msa/feign/feignclient_async/)
- [Asynchronous API Calls: Spring Boot, Feign, and Spring @Async](https://dzone.com/articles/asynchronous-api-calls-spring-boot-feign-spring-async)
