### PR TITLE
Feat/member - 사용자 정보 수정 & 조회시 응답 여부 추가

### DIFF
--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -37,6 +37,16 @@ public class MemberController {
         return ApiResponse.success(200, resp);
     }
 
+    @PatchMapping   // 멤버 정보 수정 (현재 닉네임 변경만)
+    public ApiResponse<?> updateMember(
+            @Valid @RequestBody UpdateMemberRequest req
+    ) {
+        Long memberId = authHolder.getMemberId();
+        memberService.updateMember(memberId, req);
+
+        return ApiResponse.success(204, null);
+    }
+
 
     @PostMapping("/interest")       // 니즈 수집 질문 응답 저장
     public ApiResponse<?> saveInterest(

--- a/src/main/java/org/leisureup/member/internal/domain/Interest.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Interest.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Interest {
+public class Interest extends BaseTimeEntity {
 
     @Id
     private Long memberId;

--- a/src/main/java/org/leisureup/member/internal/domain/Member.java
+++ b/src/main/java/org/leisureup/member/internal/domain/Member.java
@@ -23,4 +23,8 @@ public class Member extends BaseTimeEntity {
     public static Member of(String nickname, String email) {
         return new Member(nickname, email);
     }
+
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/org/leisureup/member/internal/dto/request/UpdateMemberRequest.java
+++ b/src/main/java/org/leisureup/member/internal/dto/request/UpdateMemberRequest.java
@@ -1,0 +1,9 @@
+package org.leisureup.member.internal.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record UpdateMemberRequest(
+        @NotBlank String nickname
+) {
+
+}

--- a/src/main/java/org/leisureup/member/internal/dto/response/GetMemberResponse.java
+++ b/src/main/java/org/leisureup/member/internal/dto/response/GetMemberResponse.java
@@ -4,12 +4,14 @@ import org.leisureup.member.internal.domain.*;
 
 public record GetMemberResponse(
         String nickname,
-        String email
+        String email,
+        boolean hasAnswered
 ) {
 
-    public static GetMemberResponse of(Member member) {
+    public static GetMemberResponse of(Member member, boolean hasAnswered) {
         return new GetMemberResponse(
-                member.getNickname(), member.getEmail()
+                member.getNickname(), member.getEmail(),
+                hasAnswered
         );
     }
 }

--- a/src/main/java/org/leisureup/member/internal/service/MemberService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberService.java
@@ -34,6 +34,20 @@ public class MemberService {
     }
 
     /**
+     * 사용자 정보를 수정한다.
+     * <p>
+     * 현재 {@code nickname} 만 변경 가능.
+     */
+    @Transactional
+    public void updateMember(Long memberId, UpdateMemberRequest req) {
+        Member find = memberRepo.findById(memberId)
+                .orElseThrow(() -> new NotFound("Member not found"));
+
+        String newNickname = req.nickname();
+        find.changeNickname(newNickname);
+    }
+
+    /**
      * 사용자 니즈 수집 질문을 저장한다.
      * <p>
      * 이전에 응답했으면 수정해 저장한다.

--- a/src/main/java/org/leisureup/member/internal/service/MemberService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberService.java
@@ -28,7 +28,9 @@ public class MemberService {
         Member find = memberRepo.findById(memberId)
                 .orElseThrow(() -> new NotFound("Member not found"));
 
-        return GetMemberResponse.of(find);
+        boolean hasAnswered = interestRepo.existsById(memberId);
+
+        return GetMemberResponse.of(find, hasAnswered);
     }
 
     /**

--- a/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
+++ b/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
@@ -84,6 +84,20 @@ class MemberServiceTest extends IntegrationTestSupport {
     }
 
     @Test
+    @DisplayName("사용자는 자신의 정보를 수정할 수 있다.")
+    void updateMember() {
+
+        String newNickname = "newNickname";
+        var req = new UpdateMemberRequest(newNickname);
+
+        service.updateMember(testMemberId, req);
+
+        var mem = memberRepo.findById(testMemberId);
+        assertThat(mem).isPresent().get()
+                .extracting(Member::getNickname).isEqualTo(newNickname);
+    }
+
+    @Test
     @DisplayName("니즈 수집 질문을 저장한다.")
     void saveInterest() {
 

--- a/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
+++ b/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
@@ -95,6 +95,12 @@ class MemberServiceTest extends IntegrationTestSupport {
         assertThat(interestRepo.findById(testMemberId))
                 .isPresent().get()
                 .hasNoNullFieldsOrProperties();
+
+        // 저장된 후에는 질문 응답 여부가 true 이다.
+        var resp = service.getMember(testMemberId);
+
+        assertThat(resp).isNotNull().hasNoNullFieldsOrProperties();
+        assertThat(resp.hasAnswered()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

1. 사용자 정보 조회시 질문 응답 여부 속성을 추가했습니다.
2. 사용자 정보 (닉네임) 을 수정하는 endpoint 를 추가했습니다.

## 💬 리뷰 요구사항 (선택)

큰 일 없으면 내일까지 merge 하겠습니다.
