### PR TITLE
Fix & Enhance - 자잘한 오류 해결 및 잘못된 parameter 응답 구성

### DIFF
--- a/src/main/java/org/leisureup/global/auth/controller/AuthController.java
+++ b/src/main/java/org/leisureup/global/auth/controller/AuthController.java
@@ -10,7 +10,6 @@ import org.leisureup.global.auth.social.*;
 import org.leisureup.global.auth.token.service.*;
 import org.leisureup.global.response.*;
 import org.leisureup.member.spi.*;
-import org.springframework.context.annotation.*;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -21,7 +20,7 @@ public class AuthController {
 
     private final SocialAuthService socialAuthService;
     private final TokenAuthService tokenAuthService;
-    private final MemberSpi memberSpi;
+    private final BypassAuth bypassAuth;
 
 
     @PostMapping            // 소셜 로그인 or 회원가입
@@ -50,17 +49,13 @@ public class AuthController {
         );
     }
 
-    @Profile("local")
     @PostMapping("/new")
     public ApiResponse<SignInUpResponse> createNewMember(
             @RequestParam SocialType type, @RequestParam String socialId,
             @RequestParam String nickname, @RequestParam String email
     ) {
-        Long id = memberSpi.saveNewMember(type, socialId, nickname, email);
-        Tokens t = tokenAuthService.createTokens(id);
-        return ApiResponse.success(
-                201,
-                SignInUpResponse.of(id, t.accessToken(), t.refreshToken())
-        );
+        var resp = bypassAuth.createNewMember(type, socialId, nickname, email);
+
+        return ApiResponse.success(201, resp);
     }
 }

--- a/src/main/java/org/leisureup/global/auth/controller/BypassAuth.java
+++ b/src/main/java/org/leisureup/global/auth/controller/BypassAuth.java
@@ -1,0 +1,28 @@
+package org.leisureup.global.auth.controller;
+
+import lombok.*;
+import org.leisureup.global.auth.dto.*;
+import org.leisureup.global.auth.dto.response.*;
+import org.leisureup.global.auth.token.service.*;
+import org.leisureup.member.spi.*;
+import org.springframework.context.annotation.*;
+import org.springframework.stereotype.*;
+
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+public class BypassAuth {
+
+    private final MemberSpi memberSpi;
+    private final TokenAuthService tokenAuthService;
+
+    public SignInUpResponse createNewMember(
+            SocialType type, String socialId,
+            String nickname, String email
+    ) {
+        Long id = memberSpi.saveNewMember(type, socialId, nickname, email);
+        Tokens t = tokenAuthService.createTokens(id);
+
+        return SignInUpResponse.of(id, t.accessToken(), t.refreshToken());
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/controller/BypassAuthOnRemote.java
+++ b/src/main/java/org/leisureup/global/auth/controller/BypassAuthOnRemote.java
@@ -1,0 +1,28 @@
+package org.leisureup.global.auth.controller;
+
+import org.leisureup.global.auth.dto.response.*;
+import org.leisureup.global.auth.token.service.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.member.spi.*;
+import org.springframework.context.annotation.*;
+import org.springframework.stereotype.*;
+
+@Component
+@Profile("!local")
+public class BypassAuthOnRemote extends BypassAuth {
+
+    public BypassAuthOnRemote(
+            MemberSpi memberSpi,
+            TokenAuthService tokenAuthService
+    ) {
+        super(memberSpi, tokenAuthService);
+    }
+
+    @Override
+    public SignInUpResponse createNewMember(
+            SocialType type, String socialId,
+            String nickname, String email
+    ) {
+        throw new BadRequestException("해당 서비스는 local profile 에서만 가능합니다.");
+    }
+}

--- a/src/main/java/org/leisureup/global/auth/dto/request/RecreateTokenRequest.java
+++ b/src/main/java/org/leisureup/global/auth/dto/request/RecreateTokenRequest.java
@@ -3,7 +3,8 @@ package org.leisureup.global.auth.dto.request;
 import jakarta.validation.constraints.*;
 
 public record RecreateTokenRequest(
-        @NotBlank String refreshToken
+        @NotBlank(message = "토큰은 비어있을 수 없습니다.")
+        String refreshToken
 ) {
 
 }

--- a/src/main/java/org/leisureup/global/auth/dto/request/SignInUpRequest.java
+++ b/src/main/java/org/leisureup/global/auth/dto/request/SignInUpRequest.java
@@ -1,10 +1,13 @@
 package org.leisureup.global.auth.dto.request;
 
 import jakarta.validation.constraints.*;
+import org.leisureup.global.validation.*;
 
 public record SignInUpRequest(
-        @NotNull AuthType authType,
-        @NotNull @NotBlank String token
+        @ValidEnum(target = AuthType.class, message = "authType 을 매칭할 수 없습니다.")
+        AuthType authType,
+        @NotBlank(message = "토큰은 비어있을 수 없습니다.")
+        String token
 ) {
 
     public enum AuthType {

--- a/src/main/java/org/leisureup/global/auth/token/service/TokenAuthService.java
+++ b/src/main/java/org/leisureup/global/auth/token/service/TokenAuthService.java
@@ -75,6 +75,8 @@ public class TokenAuthService {
         String at = atProvider.create(memberId);
         String rt = rtProvider.create(memberId);
 
+        refreshTokenRepo.save(RefreshToken.of(memberId, rt));
+
         return Tokens.of(at, rt);
     }
 }

--- a/src/main/java/org/leisureup/global/config/AdditionalJacksonConfig.java
+++ b/src/main/java/org/leisureup/global/config/AdditionalJacksonConfig.java
@@ -1,0 +1,28 @@
+package org.leisureup.global.config;
+
+import com.fasterxml.jackson.databind.*;
+import jakarta.annotation.*;
+import lombok.*;
+import org.springframework.context.annotation.*;
+
+/**
+ * Spring 이 구성한 {@code ObjectMapper} 에 추가 설정을 얹는 config class
+ */
+@Configuration
+@RequiredArgsConstructor
+public class AdditionalJacksonConfig {
+
+    private final ObjectMapper objMapper;
+
+    @PostConstruct
+    public void addConfigs() {
+        unknownEnumValuesAsNull();
+    }
+
+    /**
+     * 역직렬화에 실패한 {@code enum} 은 {@code null} 로 만든어준다.
+     */
+    private void unknownEnumValuesAsNull() {
+        objMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+    }
+}

--- a/src/main/java/org/leisureup/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/leisureup/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package org.leisureup.global.exception;
 
+import java.util.*;
 import org.leisureup.global.response.*;
+import org.springframework.validation.*;
+import org.springframework.web.bind.*;
 import org.springframework.web.bind.annotation.*;
 
 @RestControllerAdvice
@@ -13,4 +16,20 @@ public class GlobalExceptionHandler {
         return ApiResponse.failure(code, message);
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> reqArgNotValidException(MethodArgumentNotValidException e) {
+
+        List<String> errorMessages = e.getBindingResult().getFieldErrors().stream()
+                .map(GlobalExceptionHandlerUtil::extractFieldErrorMsg)
+                .toList();
+
+        return ApiResponse.failure(400, "Bad Request", errorMessages);
+    }
+}
+
+class GlobalExceptionHandlerUtil {
+
+    static String extractFieldErrorMsg(FieldError fieldError) {
+        return String.format("%s: %s", fieldError.getField(), fieldError.getDefaultMessage());
+    }
 }

--- a/src/main/java/org/leisureup/global/response/ApiResponse.java
+++ b/src/main/java/org/leisureup/global/response/ApiResponse.java
@@ -18,4 +18,8 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> failure(int code, String message) {
         return new ApiResponse<>(false, code, null, message);
     }
+
+    public static <T> ApiResponse<T> failure(int code, String message, T data) {
+        return new ApiResponse<>(false, code, data, message);
+    }
 }

--- a/src/main/java/org/leisureup/global/validation/CustomEnumValidator.java
+++ b/src/main/java/org/leisureup/global/validation/CustomEnumValidator.java
@@ -1,0 +1,25 @@
+package org.leisureup.global.validation;
+
+import jakarta.validation.*;
+import java.util.*;
+
+/**
+ * {@code enum} class validation 여부를 확인하는 class
+ */
+public class CustomEnumValidator implements ConstraintValidator<ValidEnum, Enum<?>> {
+
+    private ValidEnum validEnum;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+        validEnum = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(Enum value, ConstraintValidatorContext context) {
+        Object[] enumValues = this.validEnum.target().getEnumConstants();
+
+        return enumValues != null &&
+               Arrays.asList(enumValues).contains(value);
+    }
+}

--- a/src/main/java/org/leisureup/global/validation/ValidEnum.java
+++ b/src/main/java/org/leisureup/global/validation/ValidEnum.java
@@ -1,0 +1,68 @@
+package org.leisureup.global.validation;
+
+import jakarta.validation.*;
+import java.lang.annotation.*;
+
+/**
+ * {@code enum} 속성 validation 을 위한 annotation.
+ * <p>
+ * {@link #target}, {@link #message} 속성만 잘 구성하면 사용 가능
+ *
+ * <li>간단한 사용 방법 :</li>
+ * <pre>
+ *     {@code
+ *      public record SignInUpRequest(
+ *          @ValidEnum(target = AuthType.class, message = "authType 을 매칭할 수 없습니다.")
+ *          AuthType authType,
+ *          @NotBlank(message = "토큰은 비어있을 수 없습니다.")
+ *          String token
+ *      ) {
+ *          public enum AuthType {
+ *              APPLE, GOOGLE, KAKAO
+ *          }
+ *      }
+ *     }
+ *     {@code
+ *     {
+ *      "success": false,
+ *      "code": 400,
+ *      "data": [
+ *          "authType: authType 을 매칭할 수 없습니다."
+ *      ],
+ *      "message": "Bad Request"
+ *      }
+ *     }
+ * </pre>
+ *
+ * @see CustomEnumValidator
+ */
+@Constraint(validatedBy = {CustomEnumValidator.class})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+
+    /**
+     * Validation 에 사용할 {@code enum} class
+     */
+    Class<? extends Enum<?>> target();
+
+    /**
+     * 실패했을 때 보여줄 메시지
+     */
+    String message() default "Invalid Enum Value.";
+
+    /**
+     * 뭔지 잘 모름. Validation grouping(?) 에 사용될 수 있다고 함.
+     *
+     * @see Constraint
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * 뭔지 잘 모름. 뭔가 확장하는(?) 용도로 사용될 수 있다 함.
+     *
+     * @see Constraint
+     */
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/org/leisureup/member/internal/dto/request/SaveInterestRequest.java
+++ b/src/main/java/org/leisureup/member/internal/dto/request/SaveInterestRequest.java
@@ -1,15 +1,44 @@
 package org.leisureup.member.internal.dto.request;
 
-import jakarta.validation.constraints.*;
 import lombok.*;
+import org.leisureup.global.validation.*;
 
 public record SaveInterestRequest(
-        @NotNull AgeRange ageRange,
-        @NotNull LeisureUsual leisureUsual,
-        @NotNull PreferredStyle preferredStyle,
-        @NotNull Intensity intensity,
-        @NotNull Theme theme,
-        @NotNull AlongWith alongWith
+        @ValidEnum(
+                target = AgeRange.class,
+                message = "ageRange 을 매칭할 수 없습니다."
+        )
+        AgeRange ageRange,
+
+        @ValidEnum(
+                target = LeisureUsual.class,
+                message = "leisureUsual 을 매칭할 수 없습니다."
+        )
+        LeisureUsual leisureUsual,
+
+        @ValidEnum(
+                target = PreferredStyle.class,
+                message = "preferredStyle 을 매칭할 수 없습니다."
+        )
+        PreferredStyle preferredStyle,
+
+        @ValidEnum(
+                target = Intensity.class,
+                message = "intensity 을 매칭할 수 없습니다."
+        )
+        Intensity intensity,
+
+        @ValidEnum(
+                target = Theme.class,
+                message = "theme 을 매칭할 수 없습니다."
+        )
+        Theme theme,
+
+        @ValidEnum(
+                target = AlongWith.class,
+                message = "alongWith 을 매칭할 수 없습니다."
+        )
+        AlongWith alongWith
 ) implements CodePresentable {
 
     @Override

--- a/src/main/java/org/leisureup/member/internal/dto/request/SavePickLocationRequest.java
+++ b/src/main/java/org/leisureup/member/internal/dto/request/SavePickLocationRequest.java
@@ -3,7 +3,8 @@ package org.leisureup.member.internal.dto.request;
 import jakarta.validation.constraints.*;
 
 public record SavePickLocationRequest(
-        @NotNull @Positive
+        @NotNull(message = "locationId 는 비어있을 수 없습니다.")
+        @Positive(message = "locationId 는 0 보다 커야합니다.")
         Long locationId
 ) {
 

--- a/src/main/java/org/leisureup/member/internal/dto/request/UpdateMemberRequest.java
+++ b/src/main/java/org/leisureup/member/internal/dto/request/UpdateMemberRequest.java
@@ -3,7 +3,8 @@ package org.leisureup.member.internal.dto.request;
 import jakarta.validation.constraints.*;
 
 public record UpdateMemberRequest(
-        @NotBlank String nickname
+        @NotBlank(message = "nickname 은 비어있을 수 없습니다.")
+        String nickname
 ) {
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

자잘한 오류를 해결했습니다.

1. 로그인 또는 회원가입 시 생성된 RT 를 redis 에 저장하지 않는 오류 해결.
2. Staging 프로필에서도 `/auth/new` 를 통해 계정 생성이 가능한 오류 해결.

더불어 request body 에 올바르지 못한 속성이 있을 시 응답하는 기능을 구성했습니다.

1. `GlobalExceptionHandler` 에 관련 exception 을 핸들링 하도록 구성했습니다.
2. `enum` 속성 validation 을 위한 `@ValidEnum`, `CustomEnumValidator` 를 구성했습니다.

- 예시 :

```bash
# authType 은 APPLE, GOOGLE, KAKAO 중 하나
# token 속성 반드시 필요
curl -X 'POST' \
  'http://localhost:8080/auth' \
  -H 'accept: application/json;charset=UTF-8' \
  -H 'Content-Type: application/json;charset=UTF-8' \
  -d '{
  "authType": "unkown"
}'
```

```json
{
  "success": false,
  "code": 400,
  "data": [
    "token: 토큰은 비어있을 수 없습니다.",
    "authType: authType 을 매칭할 수 없습니다."
  ],
  "message": "Bad Request"
}
```

## 💬 리뷰 요구사항 (선택)

`None`
