### PR TITLE
Enhance/logging - 로그에 요청 ID 추가 및 파일 저장 & 디스코드 알림 전송 기능 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ configurations {
 repositories {
     mavenCentral()
     maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://jitpack.io' }
 }
 
 ext {
@@ -40,6 +41,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
 
     compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.github.napstr:logback-discord-appender:1.0.0'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -21,6 +21,9 @@ services:
     environment:
       - "SPRING_PROFILES_ACTIVE=prod"
 
+    volumes:
+      - ./logs:/LeisureUp-BE/logs
+
     depends_on:
       - redis
     networks:

--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -21,6 +21,9 @@ services:
     environment:
       - "SPRING_PROFILES_ACTIVE=staging"
 
+    volumes:
+      - ./logs:/LeisureUp-BE/logs
+
     depends_on:
       - redis
     networks:

--- a/src/main/java/org/leisureup/global/config/RequestIdHandler.java
+++ b/src/main/java/org/leisureup/global/config/RequestIdHandler.java
@@ -1,0 +1,66 @@
+package org.leisureup.global.config;
+
+import jakarta.annotation.*;
+import jakarta.servlet.*;
+import java.util.*;
+import lombok.extern.slf4j.*;
+import org.slf4j.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Component
+public class RequestIdHandler implements ServletRequestListener {
+
+    private static final int ID_LENGTH = 8;
+    private final String ridKeyOnMdc;
+
+    public RequestIdHandler(
+            @Value("${mdc-key.request-id}")
+            String ridKeyOnMdc
+    ) {
+        this.ridKeyOnMdc = ridKeyOnMdc;
+    }
+
+    private static String genRandomId() {
+        try {
+            String uuid = UUID.randomUUID().toString()
+                    .replaceAll("-", "")
+                    .substring(0, ID_LENGTH);
+
+            return String.format(
+                    "%s-%s",
+                    uuid.substring(0, ID_LENGTH / 2),
+                    uuid.substring(ID_LENGTH / 2)
+            );
+        } catch (Exception e) {
+            log.error("Failed to generate random ID", e);
+            return "UNKNOWN_ID";
+        }
+    }
+
+    @PostConstruct
+    public void validate() {
+        if (ID_LENGTH <= 0) {
+            throw new IllegalStateException("ID must be greater than zero.");
+        }
+
+        if (ridKeyOnMdc == null || ridKeyOnMdc.trim().isEmpty()) {
+            throw new IllegalStateException("MDC RID key must not be empty.");
+        }
+    }
+
+    @Override
+    public void requestInitialized(ServletRequestEvent sre) {
+        log.debug("Initializing request ID");
+        MDC.put(ridKeyOnMdc, genRandomId());
+        log.debug("Request ID has been initialized.");
+    }
+
+    @Override
+    public void requestDestroyed(ServletRequestEvent sre) {
+        log.debug("Destroying request ID");
+        MDC.remove(ridKeyOnMdc);
+        log.debug("Request ID has been destroyed.");
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,9 +13,13 @@ spring:
         - common-secret
         - staging-secret
         - init-categories
+        - file-logger
+        - discord-error-logger
       prod:
         - common-secret
         - prod-secret
+        - file-logger
+        - discord-error-logger
 
   datasource:
     url: ${db.url}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,9 +72,21 @@ feign:
 mdc-key:
   request-id: request-id
 
+logback-config:
+  # noinspection SpringBootApplicationYaml
+  log-directory: ./logs
+  # noinspection SpringBootApplicationYaml
+  discord-webhook: ${discord.webhook-url}
+
 logging:
   level:
     org.hibernate.SQL: debug
   pattern:
     level: '[RID:%10X{${mdc-key.request-id}}] %5p'
     dateformat: yyyy-MM-dd'T'HH:mm:ss.SSSz,Asia/Seoul
+  logback:
+    rollingpolicy:
+      max-file-size: 10MB
+      total-size-cap: 2GB
+      max-history: 7
+      clean-history-on-start: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,8 +69,12 @@ feign:
   weather:
     warning: http://apis.data.go.kr/1360000/WthrWrnInfoService
 
+mdc-key:
+  request-id: request-id
+
 logging:
   level:
     org.hibernate.SQL: debug
   pattern:
+    level: '[RID:%10X{${mdc-key.request-id}}] %5p'
     dateformat: yyyy-MM-dd'T'HH:mm:ss.SSSz,Asia/Seoul

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+
+  <include resource="logback/base.xml"/>
+
+  <include resource="logback/logger/file-logger.xml"/>
+
+  <include resource="logback/logger/discord-error-logger.xml"/>
+  <root level="info">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+  <springProperty name="LOG_DIR" scope="context" source="logback-config.log-directory"/>
+
+</configuration>

--- a/src/main/resources/logback/appender/discord-appender.xml
+++ b/src/main/resources/logback/appender/discord-appender.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <included>
+  <include resource="logback/base.xml"/>
+
+  <springProperty name="DISCORD_WEBHOOK_URL" scope="context" source="logback-config.discord-webhook"/>
+
   <appender class="com.github.napstr.logback.DiscordAppender" name="DISCORD">
     <avatarUrl>http://i.imgur.com/UoiA3OQ.png</avatarUrl>
     <layout class="ch.qos.logback.classic.PatternLayout">
@@ -13,10 +17,5 @@
     <username>[!!!ERROR!!!]</username>
     <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
   </appender>
-
-  <include resource="logback/base.xml"/>
-
-  <springProperty name="DISCORD_WEBHOOK_URL" scope="context"
-    source="logback-config.discord-webhook"/>
 
 </included>

--- a/src/main/resources/logback/appender/discord-appender.xml
+++ b/src/main/resources/logback/appender/discord-appender.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<included>
+  <appender class="com.github.napstr.logback.DiscordAppender" name="DISCORD">
+    <avatarUrl>http://i.imgur.com/UoiA3OQ.png</avatarUrl>
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <pattern>### 에러가 발생했어요%n- 발생 시각 : `%d{yyyy-MM-dd'T'HH:mm:ss.SSSz,Asia/Seoul}`%n- Request ID :
+        `${LOG_LEVEL_PATTERN}`%n- 레벨 : `[%-5level]`%n- 로거 : `%logger{36}`%n- 메시지 : %msg%n- 전체 로그 :
+        %n```${FILE_LOG_PATTERN}```
+      </pattern>
+    </layout>
+    <tts>false</tts>
+    <username>[!!!ERROR!!!]</username>
+    <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
+  </appender>
+
+  <include resource="logback/base.xml"/>
+
+  <springProperty name="DISCORD_WEBHOOK_URL" scope="context"
+    source="logback-config.discord-webhook"/>
+
+</included>

--- a/src/main/resources/logback/appender/error-warn-file-appender.xml
+++ b/src/main/resources/logback/appender/error-warn-file-appender.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <included>
+  <include resource="logback/base.xml"/>
+  <property name="ERROR_WARN_LOG_FILE" value="error-warn"/>
+  <property name="ERROR_WARN_FILE_PATH" value="${LOG_DIR:-./logs}/${ERROR_WARN_LOG_FILE}"/>
+
   <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="ERROR_WARN_FILE">
     <append>true</append>
     <encoder>
@@ -30,10 +34,5 @@
       </totalSizeCap>
     </rollingPolicy>
   </appender>
-
-  <include resource="logback/base.xml"/>
-  <property name="ERROR_WARN_FILE_PATH" value="${LOG_DIR:-./logs}/${ERROR_WARN_LOG_FILE}"/>
-
-  <property name="ERROR_WARN_LOG_FILE" value="error-warn"/>
 
 </included>

--- a/src/main/resources/logback/appender/error-warn-file-appender.xml
+++ b/src/main/resources/logback/appender/error-warn-file-appender.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<included>
+  <appender class="ch.qos.logback.core.rolling.RollingFileAppender" name="ERROR_WARN_FILE">
+    <append>true</append>
+    <encoder>
+      <charset>${FILE_LOG_CHARSET}</charset>
+      <pattern>${FILE_LOG_PATTERN}</pattern>
+    </encoder>
+
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>WARN</level>
+    </filter>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <cleanHistoryOnStart>
+        ${LOGBACK_ROLLINGPOLICY_CLEAN_HISTORY_ON_START:-false}
+      </cleanHistoryOnStart>
+      <fileNamePattern>
+        ${LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN:-${ERROR_WARN_FILE_PATH}.%d{yyyy-MM-dd}.%i.log}
+      </fileNamePattern>
+      <maxFileSize>
+        ${LOGBACK_ROLLINGPOLICY_MAX_FILE_SIZE:-10MB}
+      </maxFileSize>
+      <maxHistory>
+        ${LOGBACK_ROLLINGPOLICY_MAX_HISTORY:-7}
+      </maxHistory>
+      <totalSizeCap>
+        ${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP:-0}
+      </totalSizeCap>
+    </rollingPolicy>
+  </appender>
+
+  <include resource="logback/base.xml"/>
+  <property name="ERROR_WARN_FILE_PATH" value="${LOG_DIR:-./logs}/${ERROR_WARN_LOG_FILE}"/>
+
+  <property name="ERROR_WARN_LOG_FILE" value="error-warn"/>
+
+</included>

--- a/src/main/resources/logback/base.xml
+++ b/src/main/resources/logback/base.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<included>
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+</included>

--- a/src/main/resources/logback/logger/discord-error-logger.xml
+++ b/src/main/resources/logback/logger/discord-error-logger.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<included>
+  <springProfile name="discord-error-logger">
+
+    <appender class="ch.qos.logback.classic.AsyncAppender" name="ASYNC_DISCORD">
+      <appender-ref ref="DISCORD"/>
+      <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+      </filter>
+    </appender>
+
+    <include resource="logback/appender/discord-appender.xml"/>
+
+    <root level="info">
+      <appender-ref ref="ASYNC_DISCORD"/>
+    </root>
+
+  </springProfile>
+</included>

--- a/src/main/resources/logback/logger/file-logger.xml
+++ b/src/main/resources/logback/logger/file-logger.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<included>
+  <springProfile name="file-logger">
+
+    <include resource="logback/appender/error-warn-file-appender.xml"/>
+
+    <root level="info">
+      <appender-ref ref="ERROR_WARN_FILE"/>
+    </root>
+
+  </springProfile>
+</included>

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -35,9 +35,13 @@ feign:
   weather:
     warning: http://apis.data.go.kr/1360000/WthrWrnInfoService
 
+mdc-key:
+  request-id: request-id
+
 logging:
   #  level:
   #    org.hibernate.SQL: debug
   #    org.springframework.transaction: trace
   pattern:
     dateformat: yyyy-MM-dd'T'HH:mm:ss.SSSz,Asia/Seoul
+    level: '[RID:%10X{${mdc-key.request-id}}] %5p'


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

로깅과 관련된 util 기능을 추가했습니다.

1. WEB 요청별 ID 를 할당, 로깅에 포함시키도록 구성했습니다.

<details><summary> 예시</summary>

- 이전 로그 모습

<img width="1534" alt="스크린샷 2025-07-07 19 55 11" src="https://github.com/user-attachments/assets/616f5017-2351-4149-b909-a78bf53a0f69" />

- 기능 추가 후 로그 모습

<img width="1534" alt="스크린샷 2025-07-07 19 54 09" src="https://github.com/user-attachments/assets/61f103c6-268c-4fe4-a064-db0ba89e012f" />

`[RID: ac07-f3b5]` 처럼 요청별 고유한 ID 를 생성, 로그 메세지에 포함시켰습니다.

</details>

---

2. `WARN` level 이상의 로그를 파일로 저장하는 `file-logger` 를 구성했습니다.

- 설정한 rolling policy 에 따라 저장되는 모습

<img width="1577" alt="스크린샷 2025-07-07 20 16 09" src="https://github.com/user-attachments/assets/e0a16c17-350e-448f-97dd-dfe48b5999d7" />

---

3. `ERROR` level 의 로그를 discord 메시지로 보내는 `discord-error-logger` 를 구성했습니다.

위 두 로거는 아래 예시처럼 `"file-logger"`, `"discord-error-logger"` profile 을 추가해 사용할 수 있습니다.

```yaml
  profiles:
    group:
      staging:     # staging 서버에는 파일로만 로그 남기고 싶다 --> file-logger 프로필만 추가
        - common-secret
        - staging-secret
        - init-categories
        - file-logger
      prod:        # prod 서버는 디스코드 알림도 받고싶다 --> discord-error-logger 프로필 추가
        - common-secret
        - prod-secret
        - file-logger
        - discord-error-logger
```

디스코드 알림의 경우 application level 로도 구성할 수 있지만 이번에는 logback AsyncAppender 를 사용했습니다.
때문에 만약 `log.error( ... )` 와 같은 코드가 존재할 경우, 해당 에러 메시지도 디스코드로 전송됨에 주의하시길 바랍니다.

- 디스코드 알림 예시

<img width="907" alt="스크린샷 2025-07-07 20 08 06" src="https://github.com/user-attachments/assets/0c0f4bea-551f-417c-841b-84fe2f0a6a0f" />

## 💬 리뷰 요구사항 (선택)

`application-staging-secret.yaml`, `application-prod-secret.yaml` 에 디스코드 웹훅 url 비밀이 추가되었습니다.
