### PR TITLE
Feat/base-setup - 레저 종류별 필터링 검색 구현 전 기초 setup

### DIFF
--- a/src/main/java/org/leisureup/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/leisureup/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.leisureup.global.exception;
 
+import jakarta.validation.*;
 import java.util.*;
 import org.leisureup.global.response.*;
 import org.springframework.validation.*;
@@ -25,11 +26,31 @@ public class GlobalExceptionHandler {
 
         return ApiResponse.failure(400, "Bad Request", errorMessages);
     }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ApiResponse<?> constraintViolationException(ConstraintViolationException e) {
+
+        List<String> errorMessages = e.getConstraintViolations()
+                .stream()
+                .map(GlobalExceptionHandlerUtil::extractConstraintViolationMsg)
+                .toList();
+
+        return ApiResponse.failure(400, "Bad Request", errorMessages);
+    }
 }
 
 class GlobalExceptionHandlerUtil {
 
     static String extractFieldErrorMsg(FieldError fieldError) {
         return String.format("%s: %s", fieldError.getField(), fieldError.getDefaultMessage());
+    }
+
+    static String extractConstraintViolationMsg(
+            ConstraintViolation<?> constraintViolation
+    ) {
+        return String.format("%s: %s",
+                constraintViolation.getPropertyPath(),
+                constraintViolation.getMessage()
+        );
     }
 }

--- a/src/main/java/org/leisureup/global/response/external/ExternalApiResponse.java
+++ b/src/main/java/org/leisureup/global/response/external/ExternalApiResponse.java
@@ -1,0 +1,27 @@
+package org.leisureup.global.response.external;
+
+import java.util.*;
+
+/**
+ * 외부 API 응답과 관련된 계약
+ *
+ * @param <I> 응답으로부터 뽑고싶은 핵심 정보
+ */
+public interface ExternalApiResponse<I> {
+
+    /**
+     * 성공적으로 응답을 가져왔는지 여부
+     */
+    boolean isSuccess();
+
+    /**
+     * 가장 첫번째 핵심 정보를 제공
+     */
+    I getSingleItem();
+
+    /**
+     * 모든 핵심 정보를 제공
+     */
+    List<I> getItems();
+
+}

--- a/src/main/java/org/leisureup/global/response/external/tourapi/Body.java
+++ b/src/main/java/org/leisureup/global/response/external/tourapi/Body.java
@@ -1,0 +1,57 @@
+package org.leisureup.global.response.external.tourapi;
+
+import java.util.*;
+import lombok.extern.slf4j.*;
+
+@Slf4j
+public record Body<I>(
+        int numOfRows,
+        int pageNo,
+        int totalCount,
+        Items<I> items
+) {
+
+    public boolean isValid() {
+        if (numOfRows == 0) {
+            return items == null || items.item() == null || items.item().isEmpty();
+        }
+
+        List<I> itemList;
+
+        return items != null &&
+               (itemList = items.item()) != null &&
+               itemList.size() == numOfRows;
+    }
+
+    public I getSingleItem() {
+        if (numOfRows != 1) {
+            throw new IllegalStateException("Row isn't a single row");
+        }
+
+        if (!isValid()) {
+            var e = new IllegalStateException(
+                    "Expected row to be single on response, but somehow item isn't"
+            );
+            log.error("Failed to serve single item", e);
+            throw e;
+        }
+
+        return items.item().getFirst();
+    }
+
+    public List<I> getItems() {
+        if (numOfRows == 0) {
+            return Collections.emptyList();
+        }
+
+        if (!isValid()) {
+            var e = new IllegalStateException(
+                    "Expected row to be exists, but somehow item isn't"
+            );
+            log.error("Failed to serve items", e);
+            throw e;
+        }
+
+        return List.copyOf(items.item());
+    }
+}

--- a/src/main/java/org/leisureup/global/response/external/tourapi/Header.java
+++ b/src/main/java/org/leisureup/global/response/external/tourapi/Header.java
@@ -1,0 +1,23 @@
+package org.leisureup.global.response.external.tourapi;
+
+public record Header(
+        String resultCode,
+        String resultMsg
+) {
+
+    private static final String DEFAULT_SUCCESS_CODE = "0000";
+    private static final String DEFAULT_SUCCESS_MSG = "OK";
+
+    public boolean isSuccess() {
+        return DEFAULT_SUCCESS_CODE.equals(resultCode) &&
+               DEFAULT_SUCCESS_MSG.equals(resultMsg);
+    }
+
+    public boolean isSuccess(String successCode) {
+        if (successCode == null || successCode.isEmpty()) {
+            throw new IllegalArgumentException("successCode is null or empty");
+        }
+
+        return successCode.equals(resultCode);
+    }
+}

--- a/src/main/java/org/leisureup/global/response/external/tourapi/Items.java
+++ b/src/main/java/org/leisureup/global/response/external/tourapi/Items.java
@@ -1,0 +1,11 @@
+package org.leisureup.global.response.external.tourapi;
+
+import com.fasterxml.jackson.databind.annotation.*;
+import java.util.*;
+
+@JsonDeserialize(using = TourApiItemsDeserializer.class)
+public record Items<I>(
+        List<I> item
+) {
+
+}

--- a/src/main/java/org/leisureup/global/response/external/tourapi/Response.java
+++ b/src/main/java/org/leisureup/global/response/external/tourapi/Response.java
@@ -1,0 +1,67 @@
+package org.leisureup.global.response.external.tourapi;
+
+/**
+ * TourApi 응답은 대게 다음 모양처럼 구성됨
+ *
+ * <pre>
+ *     {@code
+ *      {
+ *          "response": {
+ *              "header": {
+ *                  "resultCode": "0000",
+ *                  "resultMsg": "OK"
+ *              },
+ *              "body": {
+ *                  "items": {
+ *                      "item": [
+ *                          { ... },
+ *                          { ... }
+ *                      ]
+ *                  },
+ *                  "numOfRows": 2,
+ *                  "pageNo": 1,
+ *                  "totalCount": 2
+ *              }
+ *          }
+ *      }
+ *     }
+ * </pre>
+ * <p>
+ * 만약 요청에 대한 정보 없으면 아래처럼 구성됨
+ *
+ * <pre>
+ *     {@code
+ *      {
+ *          "response": {
+ *              "header": {
+ *                  "resultCode": "0000",
+ *                  "resultMsg": "OK"
+ *              },
+ *              "body": {
+ *                  "items": "",
+ *                  "numOfRows": 0,
+ *                  "pageNo": 1,
+ *                  "totalCount": 0
+ *              }
+ *          }
+ *      }
+ *     }
+ * </pre>
+ */
+public record Response<I>(
+        Header header,
+        Body<I> body
+) {
+
+    private boolean nonNull() {
+        return header != null && body != null;
+    }
+
+    public boolean isSuccess() {
+        return nonNull() && header.isSuccess() && body.isValid();
+    }
+
+    public boolean isSuccess(String successCode) {
+        return nonNull() && header.isSuccess(successCode) && body.isValid();
+    }
+}

--- a/src/main/java/org/leisureup/global/response/external/tourapi/TourApiItemsDeserializer.java
+++ b/src/main/java/org/leisureup/global/response/external/tourapi/TourApiItemsDeserializer.java
@@ -1,0 +1,63 @@
+package org.leisureup.global.response.external.tourapi;
+
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.*;
+import java.io.*;
+import java.util.*;
+
+public class TourApiItemsDeserializer<I>
+        extends JsonDeserializer<Items<I>> implements ContextualDeserializer {
+
+    private JavaType genericItemType;
+
+    @Override
+    public Items<I> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+
+        JsonNode itemsNode = p.getCodec().readTree(p);
+
+        // 만약 {"items" : ""} 가 들어오거나 존재하지 않으면 빈 items 를 반환한다.
+        if (
+                itemsNode == null ||
+                (itemsNode.isTextual() && itemsNode.asText().isBlank())
+        ) {
+            return new Items<>(Collections.emptyList());
+        }
+
+        // 만약 {"items" : {"item" : []}} 가 들어오거나 존재하지 않으면 빈 items 를 반환한다.
+        JsonNode itemNode = itemsNode.get("item");
+        if (
+                itemNode == null || itemNode.isNull() ||
+                itemNode.isEmpty()
+        ) {
+            return new Items<>(Collections.emptyList());
+        }
+
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+        JavaType listType = mapper.getTypeFactory()
+                .constructCollectionType(List.class, genericItemType);
+        List<I> items;
+
+        if (itemNode.isArray()) {
+            items = mapper.readerFor(listType).readValue(itemNode);
+        } else {
+            // Single object case
+            I singleItem = mapper.readerFor(genericItemType).readValue(itemNode);
+            items = List.of(singleItem);
+        }
+
+        return new Items<>(items);
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(
+            DeserializationContext ctxt, BeanProperty property
+    ) {
+        JavaType wrapperType = property.getType(); // Items<I>
+        JavaType genericItemType = wrapperType.containedType(0); // I
+        TourApiItemsDeserializer<?> deserializer = new TourApiItemsDeserializer<>();
+        deserializer.genericItemType = genericItemType;
+        return deserializer;
+    }
+}

--- a/src/main/java/org/leisureup/global/response/external/tourapi/TourApiResponse.java
+++ b/src/main/java/org/leisureup/global/response/external/tourapi/TourApiResponse.java
@@ -1,0 +1,39 @@
+package org.leisureup.global.response.external.tourapi;
+
+import java.util.*;
+import lombok.extern.slf4j.*;
+import org.leisureup.global.response.external.*;
+
+@Slf4j
+public record TourApiResponse<I>(
+        Response<I> response
+) implements ExternalApiResponse<I> {
+
+    @Override
+    public boolean isSuccess() {
+        return response != null && response.isSuccess();
+    }
+
+    public boolean isSuccess(String successCode) {
+        return response != null && response.isSuccess(successCode);
+    }
+
+    public String getResultMessage() {
+        try {
+            return response.header().resultMsg();
+        } catch (Exception e) {
+            log.warn("Failed to extract result message from response", e);
+            return "";
+        }
+    }
+
+    @Override
+    public I getSingleItem() {
+        return response.body().getSingleItem();
+    }
+
+    @Override
+    public List<I> getItems() {
+        return response.body().getItems();
+    }
+}

--- a/src/main/java/org/leisureup/info/weather/controller/WeatherController.java
+++ b/src/main/java/org/leisureup/info/weather/controller/WeatherController.java
@@ -2,6 +2,7 @@ package org.leisureup.info.weather.controller;
 
 import lombok.*;
 import org.leisureup.global.response.*;
+import org.leisureup.info.weather.dto.response.*;
 import org.leisureup.info.weather.service.*;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,7 +14,7 @@ public class WeatherController {
     private final WeatherInformService weatherInformService;
 
     @GetMapping("/warning")
-    public ApiResponse<?> getWeatherWarning() {
+    public ApiResponse<WarningResponse> getWeatherWarning() {
 
         var resp = weatherInformService.getWeatherWarning();
 

--- a/src/main/java/org/leisureup/location/internal/controller/LocationController.java
+++ b/src/main/java/org/leisureup/location/internal/controller/LocationController.java
@@ -1,13 +1,14 @@
 package org.leisureup.location.internal.controller;
 
-import jakarta.validation.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import org.leisureup.global.response.*;
 import org.leisureup.location.internal.dto.response.*;
 import org.leisureup.location.internal.service.*;
+import org.springframework.validation.annotation.*;
 import org.springframework.web.bind.annotation.*;
 
+@Validated
 @RestController
 @RequestMapping("/locations")
 @RequiredArgsConstructor
@@ -15,12 +16,13 @@ public class LocationController {
 
     private final LocationService locationService;
 
-    @GetMapping("/{id}")
+    @GetMapping("/{locationId}")
     public ApiResponse<GetLocationResponse> getLocation(
-            @Valid @Positive @NotNull
-            @PathVariable Long id
+            @NotNull(message = "locationId 는 필수입니다.")
+            @Positive(message = "locationId 는 0 보다 커야합니다.")
+            @PathVariable Long locationId
     ) {
-        return ApiResponse.success(200, locationService.getLocation(id));
+        return ApiResponse.success(200, locationService.getLocation(locationId));
     }
 
 }

--- a/src/main/java/org/leisureup/map/internal/controller/MapController.java
+++ b/src/main/java/org/leisureup/map/internal/controller/MapController.java
@@ -1,14 +1,24 @@
 package org.leisureup.map.internal.controller;
 
+import jakarta.validation.*;
 import lombok.*;
+import lombok.extern.slf4j.*;
+import org.leisureup.global.exception.*;
 import org.leisureup.global.response.*;
 import org.leisureup.map.internal.dto.*;
+import org.leisureup.map.internal.dto.request.*;
+import org.leisureup.map.internal.dto.response.*;
 import org.leisureup.map.internal.service.*;
+import org.springdoc.core.annotations.*;
+import org.springframework.validation.annotation.*;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
+@Validated
 @RestController
 @RequiredArgsConstructor
 public class MapController {
+
     private final MapService mapService;
 
     @GetMapping("/map/search")
@@ -20,6 +30,20 @@ public class MapController {
         return ApiResponse.success(
                 200,
                 mapService.searchCategory(x, y, radius, category)
+        );
+    }
+
+    @GetMapping("/map/leisure/location-base")
+    public ApiResponse<MultiPageResponse<?>>
+    searchLeisureOnLocation(
+            @Valid @ParameterObject
+            SearchLeisureOnLocationRequest req
+    ) {
+
+        log.info("Request : {}", req.toString());
+
+        throw new NotImplemented(
+                "/map/leisure/location-base has not been implemented yet"
         );
     }
 }

--- a/src/main/java/org/leisureup/map/internal/controller/MapController.java
+++ b/src/main/java/org/leisureup/map/internal/controller/MapController.java
@@ -33,7 +33,7 @@ public class MapController {
         );
     }
 
-    @GetMapping("/map/leisure/location-base")
+    @GetMapping("/map/leisure")
     public ApiResponse<MultiPageResponse<?>>
     searchLeisureOnLocation(
             @Valid @ParameterObject

--- a/src/main/java/org/leisureup/map/internal/dto/request/LeisureFilter.java
+++ b/src/main/java/org/leisureup/map/internal/dto/request/LeisureFilter.java
@@ -1,0 +1,95 @@
+package org.leisureup.map.internal.dto.request;
+
+import lombok.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum LeisureFilter {
+
+    // ### EARTH category ###
+    Inline(
+            "인라인", "A03020400"
+    ), Bike(
+            "자전거 하이킹", "A03020500"
+    ), Cart(
+            "카트", "A03020600"
+    ), Golf(
+            "골프", "A03020700"
+    ), HorseRiding(
+            "승마", "A03021100"
+    ), SkiSnowboard(
+            "스키/스노보드", "A03021200"
+    ), Skate(
+            "스케이트", "A03021300"
+    ), Sledding(
+            "썰매장", "A03021400"
+    ), HuntingGround(
+            "수렵장", "A03021500"
+    ), AutoCamping(
+            "오토캠핑", "A03021700"
+    ), ShootingRange(
+            "사격장", "A03021600"
+    ), RockClimbing(
+            "암벽등반", "A03021800"
+    ), SurvivalGaming(
+            "서바이벌게임", "A03022000"
+    ), ATV(
+            "ATV", "A03022100"
+    ), MTB(
+            "MTB", "A03022200"
+    ), OffRoad(
+            "오프로드", "A03022300"
+    ), BungeeJumping(
+            "번지점프", "A03022400"
+    ), Tracking(
+            "트래킹", "A03022700"
+    ), // ### WATER category ###
+    WindsurfingJetSki(
+            "윈드서핑/제트스키", "A03030100"
+    ), KayakCanoe(
+            "카약/카누", "A03030200"
+    ), Yacht(
+            "요트", "A03030300"
+    ), SnorkelingSkinScubaDiving(
+            "스노쿨링/스킨스쿠버다이빙", "A03030400"
+    ), FreshwaterFishing(
+            "민물낚시", "A03030500"
+    ), SeaFishing(
+            "바다낚시", "A03030600"
+    ), Swimming(
+            "수영", "A03030700"
+    ), Rafting(
+            "래프팅", "A03030800"
+    ), // ### SKY category ###
+    Skydiving(
+            "스카이다이빙", "A03040100"
+    ), UltralightAircraft(
+            "초경량비행", "A03040200"
+    ), HangGlidingParagliding(
+            "행글라이딩/패러글라이딩", "A03040300"
+    ), HotAirBalloon(
+            "열기구", "A03040400"
+    );
+
+    private final String catName, fullCode;
+
+    public Code toCode() {
+        return new Code(fullCode);
+    }
+
+    @Getter
+    public static class Code {
+
+        private final String cat1, cat2, cat3;
+
+        public Code(String code) {
+            if (code == null || code.length() != 9) {
+                throw new IllegalArgumentException("Cannot parse code");
+            }
+
+            cat1 = code.substring(0, 3);
+            cat2 = code.substring(0, 5);
+            cat3 = code;
+        }
+    }
+}

--- a/src/main/java/org/leisureup/map/internal/dto/request/SearchLeisureOnLocationRequest.java
+++ b/src/main/java/org/leisureup/map/internal/dto/request/SearchLeisureOnLocationRequest.java
@@ -1,0 +1,39 @@
+package org.leisureup.map.internal.dto.request;
+
+import io.swagger.v3.oas.annotations.media.*;
+import jakarta.validation.constraints.*;
+import java.util.*;
+import lombok.*;
+import org.leisureup.global.validation.*;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchLeisureOnLocationRequest {
+
+    @ValidEnum(target = Sort.class, message = "sort 를 맵핑할 수 없습니다.")
+    @Schema(defaultValue = "DIST")
+    Sort sort = Sort.DIST;
+    @NotNull(message = "x 좌표는 필수입니다.")
+    private Double x;
+    @NotNull(message = "y 좌표는 필수입니다.")
+    private Double y;
+    @Positive(message = "radius 는 0 보다 커야합니다.")
+    @Max(value = 20_000, message = "radius 는 20,000 보다 작아야 합니다.")
+    @Schema(defaultValue = "1000")
+    private int radius = 1_000;
+    @Size(max = 5, message = "필터링은 최대 5 개 까지 가능합니다.")
+    private Set<LeisureFilter> filters;
+    @Min(value = 1, message = "page 는 1 보다 커야합니다.")
+    @Schema(defaultValue = "1")
+    private int page = 1;
+    @Min(value = 1, message = "size 는 1 보다 커야합니다.")
+    @Schema(defaultValue = "10")
+    private int size = 10;
+
+    public enum Sort {
+        DIST, TITLE, CREATION, MODIFICATION
+    }
+}

--- a/src/main/java/org/leisureup/map/internal/dto/response/MultiPageResponse.java
+++ b/src/main/java/org/leisureup/map/internal/dto/response/MultiPageResponse.java
@@ -1,0 +1,42 @@
+package org.leisureup.map.internal.dto.response;
+
+import java.util.*;
+
+public record MultiPageResponse<T>(
+        int pageNo, int pageSize,
+        int numOfPageResponse,
+        int numOfGivenElements,
+        Map<String, PageResponse<T>> elements
+) {
+
+    public static <T> MultiPageResponse<T> of(
+            int pageNo, int pageSize, Map<String, PageResponse<T>> elements
+    ) {
+
+        elements = new HashMap<>(
+                elements == null ? Collections.emptyMap() : elements
+        );
+
+        int numOfPageResponse = elements.size();
+        int numOfGivenElements = getNumOfInnerElements(elements);
+
+        return new MultiPageResponse<>(
+                pageNo, pageSize, numOfPageResponse, numOfGivenElements,
+                elements
+        );
+    }
+
+    private static <T> int getNumOfInnerElements(
+            Map<?, PageResponse<T>> map
+    ) {
+        int sum = 0;
+
+        if (map != null) {
+            for (var pageResponse : map.values()) {
+                sum += pageResponse.numOfTotalElements();
+            }
+        }
+
+        return sum;
+    }
+}

--- a/src/main/java/org/leisureup/map/internal/dto/response/PageResponse.java
+++ b/src/main/java/org/leisureup/map/internal/dto/response/PageResponse.java
@@ -1,0 +1,24 @@
+package org.leisureup.map.internal.dto.response;
+
+import java.util.*;
+
+public record PageResponse<T>(
+        int pageNo, int pageSize,
+        int numOfElements,
+        int numOfTotalElements,
+        List<T> elements
+) {
+
+    public static <T> PageResponse<T> of(
+            int pageNo, int pageSize,
+            int numOfTotalElements, List<T> elements
+    ) {
+        if (elements == null) {
+            elements = Collections.emptyList();
+        }
+        return new PageResponse<>(
+                pageNo, pageSize, elements.size(),
+                numOfTotalElements, elements
+        );
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -10,8 +10,10 @@ import org.leisureup.member.internal.dto.request.*;
 import org.leisureup.member.internal.dto.response.*;
 import org.leisureup.member.internal.service.*;
 import org.springframework.data.domain.*;
+import org.springframework.validation.annotation.*;
 import org.springframework.web.bind.annotation.*;
 
+@Validated
 @JwtAuthRequired
 @RestController
 @RequestMapping("/member")
@@ -62,8 +64,10 @@ public class MemberController {
 
     @GetMapping("/picks")       // 찜 목록 조회
     public ApiResponse<PageResponse<PickLocation>> getPickLocations(
+            @PositiveOrZero(message = "page 는 0 보다 크거나 같아야 합니다.")
             @RequestParam(value = "page", defaultValue = "0")
             int page,
+            @Positive(message = "size 는 0 보다 커야합니다.")
             @RequestParam(value = "size", defaultValue = "10")
             int size
     ) {
@@ -88,7 +92,8 @@ public class MemberController {
 
     @DeleteMapping("/picks/{locationId}")       // 찜 장소 삭제
     public ApiResponse<?> deletePickLocation(
-            @Valid @Positive @NotNull
+            @NotNull(message = "locationId 는 필수입니다.")
+            @Positive(message = "locationId 는 0 보다 커야합니다.")
             @PathVariable Long locationId
     ) {
         Long memberId = authHolder.getMemberId();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

`레저 종류별 검색 기능` 구현 전, 바탕이 될만한 기초 setup 을 진행했습니다.

1. `TourApi` 응답을 global 하게 사용할 수 있도록 `TourApiResponse<I>` 등을 구성했습니다.
    대부분의 내용은 `org/leisureup/location/internal/dto/api` 에서 작업한 것과 동일합니다.

2. `레저 종류별 검색 기능` 중 `키워드를 사용하지 않고 검색` 에 대한 endpoint 를 구성했습니다.
    기능 구현은 아직 진행하지 않고 endpoint 만 구성했습니다.

3. Controller 의 `@RequestParam` 에 대해서도 valid 여부를 파악, invalid 시 응답으로 제공하는 기능을 추가하였습니다.

## 💬 리뷰 요구사항 (선택)

`TourApi` 에 대한 공통 형식을 구성하였으니 관련된 부분은 추후 refactor 하도록 하겠습니다.
`(org/leisureup/location/internal/dto/api)`