### PR TITLE
Feat/recommend - 카테고리, 장소 추천 기능 수정

### DIFF
--- a/src/main/java/org/leisureup/info/recommend/controller/RecommendController.java
+++ b/src/main/java/org/leisureup/info/recommend/controller/RecommendController.java
@@ -17,8 +17,8 @@ public class RecommendController {
     private final RecommendService recommendService;
 
     @JwtAuthIfPossible
-    @GetMapping("/member")  // 사용자 질문 응답 기반 장소 추천
-    public ApiResponse<List<LocationInfo>> recommendOnMember() {
+    @GetMapping("/member")  // 사용자 질문 응답 기반 레조 (카테고리) 종류를 추천
+    public ApiResponse<List<CategoryRecommendation>> recommendOnMember() {
 
         Long memberId = authHolder.getMemberId();
 
@@ -29,8 +29,8 @@ public class RecommendController {
         );
     }
 
-    @GetMapping("/season")  // 계절에 맞는 레저 (카테고리) 종류를 추천
-    public ApiResponse<List<RecommendOnSeason>> recommendOnSeason() {
+    @GetMapping("/season")  // 계절에 맞는 레저 장소를 추천
+    public ApiResponse<List<LocationRecommendation>> recommendOnSeason() {
 
         var resp = recommendService.recommendOnSeason();
 

--- a/src/main/java/org/leisureup/info/recommend/dto/PrioritizedCategoryInfo.java
+++ b/src/main/java/org/leisureup/info/recommend/dto/PrioritizedCategoryInfo.java
@@ -8,6 +8,7 @@ import org.springframework.lang.*;
 public record PrioritizedCategoryInfo(
         Long categoryId,
         String name,
+        String thumbnailUrl,
         double score
 ) implements Comparable<PrioritizedCategoryInfo> {
 

--- a/src/main/java/org/leisureup/info/recommend/dto/response/CategoryRecommendation.java
+++ b/src/main/java/org/leisureup/info/recommend/dto/response/CategoryRecommendation.java
@@ -1,6 +1,6 @@
 package org.leisureup.info.recommend.dto.response;
 
-public record RecommendOnSeason(
+public record CategoryRecommendation(
         Long categoryId,
         String name,
         String thumbnailUrl

--- a/src/main/java/org/leisureup/info/recommend/dto/response/LocationRecommendation.java
+++ b/src/main/java/org/leisureup/info/recommend/dto/response/LocationRecommendation.java
@@ -1,9 +1,6 @@
 package org.leisureup.info.recommend.dto.response;
 
-import io.swagger.v3.oas.annotations.media.*;
-
-@Schema(name = "LocationInfoOnRecommend")
-public record LocationInfo(
+public record LocationRecommendation(
         Long id,
         String name,
         String largeThumbnail,

--- a/src/main/java/org/leisureup/info/recommend/service/PrioritizingService.java
+++ b/src/main/java/org/leisureup/info/recommend/service/PrioritizingService.java
@@ -43,12 +43,13 @@ public class PrioritizingService {
     ) {
         Long id = category.id();
         String name = category.name();
+        String thumbnailUrl = category.thumbnailUrl();
 
         String code1 = memberCode.code();
         String code2 = category.recommendingCode();
 
         return new PrioritizedCategoryInfo(
-                id, name, scoring.score(code1, code2)
+                id, name, thumbnailUrl, scoring.score(code1, code2)
         );
     }
 }

--- a/src/main/java/org/leisureup/info/recommend/service/RecommendService.java
+++ b/src/main/java/org/leisureup/info/recommend/service/RecommendService.java
@@ -6,7 +6,7 @@ import lombok.*;
 import lombok.extern.slf4j.*;
 import org.leisureup.info.recommend.dto.*;
 import org.leisureup.info.recommend.dto.response.*;
-import org.leisureup.info.recommend.dto.response.LocationInfo.*;
+import org.leisureup.info.recommend.dto.response.LocationRecommendation.*;
 import org.leisureup.location.spi.*;
 import org.leisureup.member.spi.*;
 import org.springframework.stereotype.*;
@@ -16,37 +16,45 @@ import org.springframework.stereotype.*;
 @RequiredArgsConstructor
 public class RecommendService {
 
+    /**
+     * 사용자가 관심있는 카테고리를 추려낼 최대 개수
+     */
+    private static final int DEFAULT_RECOMMENDING_CATEGORY_SIZE = 10;
+
+    /**
+     * 장소 추천으로 제공할 최대 장소 개수
+     */
     private static final int DEFAULT_RECOMMENDING_SIZE = 50;
-    private static final int DEFAULT_RECOMMENDING_CATEGORY_SIZE = 5;
+
     private final MemberSpi memberSpi;
     private final CategorySpi categorySpi;
     private final LocationQueryPort locationQueryPort;
     private final PrioritizingService prioritizingService;
 
     /**
-     * 로그인 하지 않은 사용자에게 장소를 추천
+     * 로그인 하지 않은 사용자에게 임의의 카테고리 (레저 종류) 목록을 추천
      */
-    public List<LocationInfo> recommendOnAnonymous() {
+    public List<CategoryRecommendation> recommendOnAnonymous() {
 
-        List<LocationResponse> locations
-                = locationQueryPort.getAnyLocations(DEFAULT_RECOMMENDING_SIZE);
+        List<CategoryInfo> categories
+                = categorySpi.getAnyCategories(DEFAULT_RECOMMENDING_CATEGORY_SIZE);
 
-        return locations.stream()
+        return categories.stream()
                 .map(RecommendServiceUtil::toResponse)
                 .toList();
     }
 
 
     /**
-     * 로그인한 사용자에게 장소를 추천
+     * 로그인한 사용자에게 카테고리 (레저 종류) 목록을 추천
      */
-    public List<LocationInfo> recommendOnMember(
+    public List<CategoryRecommendation> recommendOnMember(
             Long memberId
     ) {
 
         Optional<InterestCode> optional = memberSpi.getInterest(memberId);
 
-        // 질문 응답을 한지 않았으면 그냥 평이한 장소 추천
+        // 질문 응답을 한지 않았으면 그냥 평이한 카테고리 추천
         if (optional.isEmpty()) {
             return this.recommendOnAnonymous();
         }
@@ -54,31 +62,31 @@ public class RecommendService {
         // 모든 카테고리 중
         List<CategoryInfo> allCategories = categorySpi.getAllCategories();
 
-        // 사용자가 관심있는 카테고리 ID 만 끌어낸다.
-        List<Long> categoriesInInterest = prioritizingService.prioritize(
+        // 사용자가 관심있는 카테고리만 끌어내 반환한다.
+        return prioritizingService.prioritize(
                         optional.get(), allCategories,
                         DEFAULT_RECOMMENDING_CATEGORY_SIZE
-                ).stream().map(PrioritizedCategoryInfo::categoryId)
-                .toList();
-
-        // 정보 조회해 반환한다.
-        return locationQueryPort.getAnyLocationsOnCategory(
-                        DEFAULT_RECOMMENDING_SIZE, categoriesInInterest
-                ).stream().map(RecommendServiceUtil::toResponse)
+                ).stream()
+                .map(RecommendServiceUtil::toResponse)
                 .toList();
     }
 
     /**
-     * 계절에 따른 레저 (카테고리) 목록을 추천
+     * 계절에 맞는 여행 장소 목록을 추천
      */
-    public List<RecommendOnSeason> recommendOnSeason() {
+    public List<LocationRecommendation> recommendOnSeason() {
 
         // 모든 카테고리를 가져온다.
-        List<CategoryInfo> allCategories = categorySpi.getAllCategories();
-
-        // 카테고리 중 임의의 계절에 어올리거나 현재 계절에 맞는 카테고리만 filter 한다.
-        return allCategories.stream()
+        // 카테고리 중 현재 계절에 적합한 카테고리만 filter, ID 만 가져온다.
+        List<Long> seasonCategoryIds = categorySpi.getAllCategories().stream()
                 .filter(RecommendServiceUtil::filterOnCurrentSeason)
+                .map(CategoryInfo::id)
+                .toList();
+
+        // 카테고리에 속한 임의의 장소를 반환한다.
+        return locationQueryPort.getAnyLocationsOnCategory(
+                        DEFAULT_RECOMMENDING_SIZE, seasonCategoryIds
+                ).stream()
                 .map(RecommendServiceUtil::toResponse)
                 .toList();
     }
@@ -87,7 +95,7 @@ public class RecommendService {
 
 class RecommendServiceUtil {
 
-    static LocationInfo toResponse(LocationResponse location) {
+    static LocationRecommendation toResponse(LocationResponse location) {
         Long id = location.locationId();
         String name = location.title();
         var desc = location.description();
@@ -99,7 +107,7 @@ class RecommendServiceUtil {
             th2 = desc.smallThumbnail();
         }
 
-        return new LocationInfo(
+        return new LocationRecommendation(
                 id, name, emptyIfNull(th1), emptyIfNull(th2), category
         );
     }
@@ -128,9 +136,17 @@ class RecommendServiceUtil {
         return seasons.contains(Season.ANY) || seasons.contains(getCurrentSeason());
     }
 
-    static RecommendOnSeason toResponse(CategoryInfo categoryInfo) {
-        return new RecommendOnSeason(
+    static CategoryRecommendation toResponse(CategoryInfo categoryInfo) {
+        return new CategoryRecommendation(
                 categoryInfo.id(), categoryInfo.name(),
+                categoryInfo.thumbnailUrl()
+        );
+    }
+
+    static CategoryRecommendation toResponse(PrioritizedCategoryInfo categoryInfo) {
+        return new CategoryRecommendation(
+                categoryInfo.categoryId(),
+                categoryInfo.name(),
                 categoryInfo.thumbnailUrl()
         );
     }

--- a/src/main/java/org/leisureup/location/internal/repository/CategoryRepository.java
+++ b/src/main/java/org/leisureup/location/internal/repository/CategoryRepository.java
@@ -2,9 +2,12 @@ package org.leisureup.location.internal.repository;
 
 import java.util.*;
 import org.leisureup.location.internal.domain.*;
+import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.*;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findByCategoryCode(String categoryCode);
+
+    List<Category> findAllBy(Pageable pageable);
 }

--- a/src/main/java/org/leisureup/location/spi/CategorySpi.java
+++ b/src/main/java/org/leisureup/location/spi/CategorySpi.java
@@ -13,4 +13,11 @@ public interface CategorySpi {
      * 특정 카테고리의 세부 정보를 조회
      */
     DetailedCategoryInfo getCategoryDetail(Long categoryId);
+
+    /**
+     * 최대 {@code maxElements} 만큼의 카테고리를 조회
+     * <p>
+     * 조회되는 카테고리는 랜덤하게 변할 수 있음.
+     */
+    List<CategoryInfo> getAnyCategories(int maxElements);
 }

--- a/src/main/java/org/leisureup/location/spi/internal/CategorySpiImpl.java
+++ b/src/main/java/org/leisureup/location/spi/internal/CategorySpiImpl.java
@@ -1,6 +1,7 @@
 package org.leisureup.location.spi.internal;
 
 import java.util.*;
+import java.util.concurrent.*;
 import java.util.stream.*;
 import lombok.*;
 import org.leisureup.global.exception.*;
@@ -8,6 +9,7 @@ import org.leisureup.location.internal.domain.*;
 import org.leisureup.location.internal.domain.AdditionalCategoryInfo.*;
 import org.leisureup.location.internal.repository.*;
 import org.leisureup.location.spi.*;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.*;
 
 @Component
@@ -31,9 +33,29 @@ public class CategorySpiImpl implements CategorySpi {
 
         return CategorySpiUtil.toDetailedRecord(find);
     }
+
+    @Override
+    public List<CategoryInfo> getAnyCategories(int maxElements) {
+
+        long cnt = categoryRepo.count();
+
+        if (cnt == 0) {
+            return Collections.emptyList();
+        }
+
+        List<Category> categories = categoryRepo.findAllBy(
+                CategorySpiUtil.randomPageRequest(maxElements, cnt)
+        );
+
+        return categories.stream()
+                .map(CategorySpiUtil::toRecord)
+                .toList();
+    }
 }
 
 class CategorySpiUtil {
+
+    private static final Random RAND = ThreadLocalRandom.current();
 
     static CategoryInfo toRecord(Category category) {
         Long id = category.getId();
@@ -121,5 +143,17 @@ class CategorySpiUtil {
 
     private static String emptyIfNull(String s) {
         return s == null ? "" : s;
+    }
+
+    static Pageable randomPageRequest(
+            int pageSize, long totalElements
+    ) {
+        int total = totalElements > Integer.MAX_VALUE ?
+                Integer.MAX_VALUE : (int) totalElements;
+
+        int totalPages = Math.ceilDiv(total, pageSize);
+        int randomPage = RAND.nextInt(totalPages);
+
+        return PageRequest.of(randomPage, pageSize);
     }
 }

--- a/src/test/java/org/leisureup/location/spi/CategorySpiTest.java
+++ b/src/test/java/org/leisureup/location/spi/CategorySpiTest.java
@@ -68,9 +68,22 @@ class CategorySpiTest extends IntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("카테고리가 없을땐 에러가 발생한다.")
+    @DisplayName("조회할 카테고리가 없을땐 에러가 발생한다.")
     void testNotFound() {
         assertThatThrownBy(() -> categorySpi.getCategoryDetail(nonExistingId))
                 .isInstanceOf(NotFound.class);
+    }
+
+    @Test
+    @DisplayName("랜덤한 카테고리를 제공받을 수 있다.")
+    void getAnyCategories() {
+
+        int max = 3;    // id1, 2, 3 --> max 3
+        List<CategoryInfo> resp = categorySpi.getAnyCategories(max);
+
+        assertThat(resp).isNotNull();
+        for (var one : resp) {
+            assertThat(one).hasNoNullFieldsOrProperties();
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

1. 카테고리 추천을 위한 `CategorySpi#getAnyCategories` 를 추가했습니다.
2. `/recommend/member` endpoint 에서 `레저 종류 (카테고리)` 를 추천받도록 변경했습니다.
3. `/recommend/season` endpoint 에서 계절에 적합한 `장소` 를 추천받도록 변경했습니다.

## 💬 리뷰 요구사항 (선택)

`None`
