### PR TITLE
Refactor/map - 지도 검색 응답에 장소 ID `(contentId)` 및 사소한 기능 추가

### DIFF
--- a/src/main/java/org/leisureup/map/internal/dto/MapResponse.java
+++ b/src/main/java/org/leisureup/map/internal/dto/MapResponse.java
@@ -1,12 +1,7 @@
 package org.leisureup.map.internal.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
@@ -14,6 +9,7 @@ import java.util.List;
 @Builder
 public class MapResponse {
     // 영업시간, 예약 가능 필드 없음!!!!
+    private Long contentId;
     private String category;
     private String addr1; // 주소
     private String addr2; // 상세주소
@@ -45,6 +41,7 @@ public class MapResponse {
         List<MapResponse> mapResponses = new ArrayList<>();
         for (TourApiResponse.Item item : tourApiResponse.getResponse().getBody().getItems().getItem()) {
             MapResponse build = MapResponse.builder()
+                    .contentId(item.getContentid())
                     .category(category)
                     .addr1(item.getAddr1())
                     .addr2(item.getAddr2())

--- a/src/main/java/org/leisureup/map/internal/dto/TourApiResponse.java
+++ b/src/main/java/org/leisureup/map/internal/dto/TourApiResponse.java
@@ -1,10 +1,7 @@
 package org.leisureup.map.internal.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
-
-import java.util.List;
+import java.util.*;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
@@ -55,7 +52,7 @@ public class TourApiResponse {
         private String cat1; // 대분류
         private String cat2; // 중분류
         private String cat3; // 소분류
-        private String contentid; // 콘텐츠ID
+        private Long contentid; // 콘텐츠ID
         private String contenttypeid; // 콘텐츠타입ID
         private String createdtime; // 등록일
         private String dist; // 거리

--- a/src/main/java/org/leisureup/member/internal/repository/PickRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/PickRepository.java
@@ -1,5 +1,6 @@
 package org.leisureup.member.internal.repository;
 
+import java.util.*;
 import org.leisureup.member.internal.domain.*;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.*;
@@ -18,4 +19,10 @@ public interface PickRepository extends JpaRepository<Pick, PickCompositeKey> {
     )
     Page<Pick> findAllByMemberId(Long memberId, Pageable pageable);
 
+    @Query("""
+            select p.locationId from Pick p
+            where p.member.id = :memberId
+            and p.locationId in :locationIds
+            """)
+    List<Long> filterLocationIdsInPick(Long memberId, List<Long> locationIds);
 }

--- a/src/main/java/org/leisureup/member/spi/PickSpi.java
+++ b/src/main/java/org/leisureup/member/spi/PickSpi.java
@@ -1,0 +1,14 @@
+package org.leisureup.member.spi;
+
+import java.util.*;
+
+public interface PickSpi {
+
+    /**
+     * 장소 ID 중 사용자가 찜한 장소를 식별해 ID 로 제공
+     */
+    List<Long> filterPickedLocationFromMember(
+            Long memberId, List<Long> locationIds
+    );
+
+}

--- a/src/main/java/org/leisureup/member/spi/internal/PickSpiImpl.java
+++ b/src/main/java/org/leisureup/member/spi/internal/PickSpiImpl.java
@@ -1,0 +1,28 @@
+package org.leisureup.member.spi.internal;
+
+import java.util.*;
+import lombok.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.stereotype.*;
+
+@Component
+@RequiredArgsConstructor
+public class PickSpiImpl implements PickSpi {
+
+    private final MemberRepository memberRepo;
+    private final PickRepository pickRepo;
+
+    @Override
+    public List<Long> filterPickedLocationFromMember(
+            Long memberId, List<Long> locationIds
+    ) {
+
+        memberRepo.findById(memberId).orElseThrow(
+                () -> new NotFound("Member not found")
+        );
+
+        return pickRepo.filterLocationIdsInPick(memberId, locationIds);
+    }
+}

--- a/src/test/java/org/leisureup/member/spi/PickSpiTest.java
+++ b/src/test/java/org/leisureup/member/spi/PickSpiTest.java
@@ -1,0 +1,102 @@
+package org.leisureup.member.spi;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.*;
+import java.util.stream.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.junit.jupiter.api.*;
+import org.leisureup.*;
+import org.leisureup.global.exception.*;
+import org.leisureup.member.internal.domain.*;
+import org.leisureup.member.internal.repository.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Slf4j
+class PickSpiTest extends IntegrationTestSupport {
+
+    private static final List<Long> pickedLocationIds
+            = LongStream.rangeClosed(1, 10).boxed().toList();
+    private static final Long invalidMemberId = Long.MAX_VALUE;
+    private static Long testMemberId;
+
+    @Autowired
+    PickSpiTestInitializer testInitializer;
+
+    @Autowired
+    PickSpi pickSpi;
+
+    @Autowired
+    MemberRepository memberRepo;
+
+    @Autowired
+    PickRepository pickRepo;
+
+    @BeforeEach
+    void setUp() {
+        Member save = testInitializer.initializeData(pickedLocationIds);
+        testMemberId = save.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        pickRepo.deleteAll();
+        memberRepo.deleteAll();
+        testMemberId = null;
+    }
+
+    @Test
+    @DisplayName("장소 중 사용자가 찜한 장소를 식별할 수 있다.")
+    void filterPickedLocationFromMember() {
+
+        List<Long> sublist = pickedLocationIds.subList(1, pickedLocationIds.size() / 2);
+
+        List<Long> locationIds = new ArrayList<>(sublist);
+        locationIds.addAll(
+                List.of(Long.MAX_VALUE, Long.MAX_VALUE - 1, Long.MAX_VALUE - 2)
+        );
+
+        var resp = pickSpi.filterPickedLocationFromMember(testMemberId, locationIds);
+
+        assertThat(resp).isNotNull()
+                .hasSize(sublist.size())
+                .containsAll(sublist);
+    }
+
+    @Test
+    @DisplayName("사용자를 식별할 수 없으면 에러를 일으킨다.")
+    void testInvalidMemberId() {
+
+        assertThatThrownBy(() -> pickSpi.filterPickedLocationFromMember(
+                invalidMemberId, pickedLocationIds
+        ))
+                .isInstanceOf(NotFound.class);
+
+    }
+}
+
+@Component
+@RequiredArgsConstructor
+class PickSpiTestInitializer {
+
+    private final MemberRepository memberRepo;
+    private final PickRepository pickRepo;
+
+    @Transactional
+    Member initializeData(List<Long> locationIds) {
+        Member save = memberRepo.save(
+                Member.of("test", "test")
+        );
+
+        List<Pick> picks = new ArrayList<>();
+        for (Long locationId : locationIds) {
+            picks.add(Pick.of(save, locationId));
+        }
+        pickRepo.saveAll(picks);
+
+        return save;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

1. `/map/search`, `/map/category` 응답 속성에 장소 ID `(contentId)` 를 추가하였습니다. `(TourAPI 사용했을 때만 구성)`
2. 이후 검색 페이지에서 `장소를 찜했는지 여부` 가 필요할 것 같아 관련 SPI 기능을 추가하였습니다. `(PickSpi.java)`

## 💬 리뷰 요구사항 (선택)

`None`