### PR TITLE
Feat/withdraw - 회원 삭제 기능 구성

### DIFF
--- a/src/main/java/org/leisureup/global/auth/token/service/TokenAuthService.java
+++ b/src/main/java/org/leisureup/global/auth/token/service/TokenAuthService.java
@@ -2,13 +2,17 @@ package org.leisureup.global.auth.token.service;
 
 import java.util.*;
 import lombok.*;
+import lombok.extern.slf4j.*;
 import org.leisureup.global.auth.dto.*;
 import org.leisureup.global.auth.token.internal.*;
 import org.leisureup.global.auth.token.repository.*;
 import org.leisureup.global.exception.*;
 import org.leisureup.member.spi.*;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.*;
 import org.springframework.stereotype.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenAuthService {
@@ -78,5 +82,17 @@ public class TokenAuthService {
         refreshTokenRepo.save(RefreshToken.of(memberId, rt));
 
         return Tokens.of(at, rt);
+    }
+
+    @Async
+    @EventListener
+    public void handleMemberRemovalEvent(MemberRemovalEvent event) {
+        Long memberId = event.memberId();
+
+        log.info("Member removal event received with ID: {}", memberId);
+
+        refreshTokenRepo.deleteById(memberId);
+
+        log.info("Refresh token has been removed for ID: {}", memberId);
     }
 }

--- a/src/main/java/org/leisureup/global/config/AsyncExecutorConfig.java
+++ b/src/main/java/org/leisureup/global/config/AsyncExecutorConfig.java
@@ -13,7 +13,7 @@ public class AsyncExecutorConfig {
 
     private final RequestAndTraceIdDecorator requestAndTraceIdDecorator;
 
-    @Bean
+    @Bean(name = "taskExecutor")
     public Executor asyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setVirtualThreads(true);

--- a/src/main/java/org/leisureup/location/internal/service/DataSyncEventHandler.java
+++ b/src/main/java/org/leisureup/location/internal/service/DataSyncEventHandler.java
@@ -91,7 +91,6 @@ public class DataSyncEventHandler {
         Optional<CommonInfoCache> cache = commonInfoCacheRepo.findById(locationId);
 
         if (cache.isPresent()) {
-            log.info("cache!");
             replace = cache.get().getInfo();
             commonInfoCacheRepo.delete(cache.get());
         } else {

--- a/src/main/java/org/leisureup/member/internal/controller/MemberController.java
+++ b/src/main/java/org/leisureup/member/internal/controller/MemberController.java
@@ -49,6 +49,13 @@ public class MemberController {
         return ApiResponse.success(204, null);
     }
 
+    @DeleteMapping  // 멤버 삭제
+    public ApiResponse<?> deleteMember() {
+        Long memberId = authHolder.getMemberId();
+        memberService.deleteMember(memberId);
+
+        return ApiResponse.success(204, null);
+    }
 
     @PostMapping("/interest")       // 니즈 수집 질문 응답 저장
     public ApiResponse<?> saveInterest(

--- a/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/AppleOAuthRepository.java
@@ -13,4 +13,12 @@ public interface AppleOAuthRepository
             where ao.id = :socialId
             """)
     Optional<Long> findMemberIdBySocial(String socialId);
+
+    @Query("""
+            delete AppleOAuth ao where ao.member.id = :memberId
+            """)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    void deleteByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/GoogleOAuthRepository.java
@@ -13,4 +13,12 @@ public interface GoogleOAuthRepository
             where go.id = :socialId
             """)
     Optional<Long> findMemberIdBySocial(String socialId);
+
+    @Query("""
+            delete GoogleOAuth go where go.member.id = :memberId
+            """)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    void deleteByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/org/leisureup/member/internal/repository/InterestRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/InterestRepository.java
@@ -5,4 +5,9 @@ import org.springframework.data.jpa.repository.*;
 
 public interface InterestRepository extends JpaRepository<Interest, Long> {
 
+    @Query("""
+            delete Interest itr where itr.member.id = :memberId
+            """)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/KakaoOAuthRepository.java
@@ -13,4 +13,12 @@ public interface KakaoOAuthRepository
             where ko.id = :socialId
             """)
     Optional<Long> findMemberIdBySocial(String socialId);
+
+    @Query("""
+            delete KakaoOAuth ko where ko.member.id = :memberId
+            """)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    void deleteByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/org/leisureup/member/internal/repository/PickRepository.java
+++ b/src/main/java/org/leisureup/member/internal/repository/PickRepository.java
@@ -25,4 +25,12 @@ public interface PickRepository extends JpaRepository<Pick, PickCompositeKey> {
             and p.locationId in :locationIds
             """)
     List<Long> filterLocationIdsInPick(Long memberId, List<Long> locationIds);
+
+    @Query("""
+            delete Pick p where p.member.id = :memberId
+            """)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    void deleteByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/org/leisureup/member/internal/service/MemberRemovalService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberRemovalService.java
@@ -1,0 +1,43 @@
+package org.leisureup.member.internal.service;
+
+import lombok.*;
+import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
+import org.springframework.context.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Service
+@RequiredArgsConstructor
+public class MemberRemovalService {
+
+    private final AppleOAuthRepository appleOAuthRepo;
+    private final GoogleOAuthRepository googleOAuthRepo;
+    private final KakaoOAuthRepository kakaoOAuthRepo;
+
+    private final PickRepository pickRepo;
+    private final InterestRepository interestRepo;
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void removeRelatedOAuths(Long memberId) {
+        appleOAuthRepo.deleteByMemberId(memberId);
+        googleOAuthRepo.deleteByMemberId(memberId);
+        kakaoOAuthRepo.deleteByMemberId(memberId);
+    }
+
+    @Transactional
+    public void removeRelatedPicks(Long memberId) {
+        pickRepo.deleteByMemberId(memberId);
+    }
+
+    @Transactional
+    public void removeRelatedInterest(Long memberId) {
+        interestRepo.deleteByMemberId(memberId);
+    }
+
+    public void publishMemberRemovalEvent(Long memberId) {
+        eventPublisher.publishEvent(new MemberRemovalEvent(memberId));
+    }
+}

--- a/src/main/java/org/leisureup/member/internal/service/MemberService.java
+++ b/src/main/java/org/leisureup/member/internal/service/MemberService.java
@@ -22,6 +22,7 @@ public class MemberService {
     private final PickRepository pickRepo;
     private final LocationQueryPort locationQueryPort;
     private final LocationFetchSpi locationFetchSpi;
+    private final MemberRemovalService memberRemovalService;
 
     /**
      * 사용자 정보를 조회한다.
@@ -47,6 +48,24 @@ public class MemberService {
 
         String newNickname = req.nickname();
         find.changeNickname(newNickname);
+    }
+
+    /**
+     * 사용자를 삭제한다.
+     */
+    @Transactional
+    public void deleteMember(Long memberId) {
+
+        Member target = memberRepo.findById(memberId)
+                .orElseThrow(() -> new NotFound("Member not found"));
+
+        memberRemovalService.removeRelatedPicks(memberId);
+        memberRemovalService.removeRelatedInterest(memberId);
+        memberRemovalService.removeRelatedOAuths(memberId);
+
+        memberRepo.delete(target);
+
+        memberRemovalService.publishMemberRemovalEvent(memberId);
     }
 
     /**

--- a/src/main/java/org/leisureup/member/spi/MemberRemovalEvent.java
+++ b/src/main/java/org/leisureup/member/spi/MemberRemovalEvent.java
@@ -1,0 +1,7 @@
+package org.leisureup.member.spi;
+
+public record MemberRemovalEvent(
+        Long memberId
+) {
+
+}

--- a/src/test/java/org/leisureup/location/internal/service/DataSyncEventHandlerTest.java
+++ b/src/test/java/org/leisureup/location/internal/service/DataSyncEventHandlerTest.java
@@ -193,7 +193,7 @@ class DataSyncEventHandlerTest extends IntegrationTestSupport {
 
         await()
                 .atMost(Duration.ofSeconds(5L))
-                .pollDelay(Duration.ofMillis(1000L))
+                .pollDelay(Duration.ofMillis(100L))
                 .untilAsserted(() -> {
                     Location modified = locationRepo.findById(testId)
                             .orElseThrow();

--- a/src/test/java/org/leisureup/member/internal/service/MemberRemovalServiceTest.java
+++ b/src/test/java/org/leisureup/member/internal/service/MemberRemovalServiceTest.java
@@ -1,0 +1,160 @@
+package org.leisureup.member.internal.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.junit.jupiter.api.*;
+import org.leisureup.*;
+import org.leisureup.member.internal.domain.*;
+import org.leisureup.member.internal.dto.request.*;
+import org.leisureup.member.internal.dto.request.SaveInterestRequest.*;
+import org.leisureup.member.internal.repository.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Slf4j
+class MemberRemovalServiceTest extends IntegrationTestSupport {
+
+    private static Long testMemberId;
+
+    @Autowired
+    AppleOAuthRepository appleOAuthRepo;
+    @Autowired
+    GoogleOAuthRepository googleOAuthRepo;
+    @Autowired
+    KakaoOAuthRepository kakaoOAuthRepo;
+
+    @Autowired
+    MemberRepository memberRepo;
+    @Autowired
+    PickRepository pickRepo;
+    @Autowired
+    InterestRepository interestRepo;
+
+    @Autowired
+    MemberRemovalService memberRemovalService;
+
+    @Autowired
+    MemberRemovalServiceTestInitializer testInitializer;
+
+
+    @BeforeEach
+    void setUp() {
+        testMemberId = memberRepo.save(
+                Member.of("test", "test")
+        ).getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        appleOAuthRepo.deleteAll();
+        googleOAuthRepo.deleteAll();
+        kakaoOAuthRepo.deleteAll();
+        pickRepo.deleteAll();
+        interestRepo.deleteAll();
+        memberRepo.deleteAll();
+    }
+
+    @Test
+    @DisplayName("사용자와 연관된 소셜 정보들이 삭제된다.")
+    void removeRelatedOAuths() {
+
+        testInitializer.initOAuths(testMemberId);
+
+        List<Predicate<Long>> predicates = List.of(
+                appleOAuthRepo::existsByMemberId,
+                googleOAuthRepo::existsByMemberId,
+                kakaoOAuthRepo::existsByMemberId
+        );
+
+        for (var pred : predicates) {
+            assertThat(pred.test(testMemberId)).isTrue();
+        }
+
+        memberRemovalService.removeRelatedOAuths(testMemberId);
+
+        for (var pred : predicates) {
+            assertThat(pred.test(testMemberId)).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("사용자와 연관된 찜 목록들이 삭제된다.")
+    void removeRelatedPicks() {
+
+        testInitializer.initPicks(testMemberId);
+
+        assertThat(pickRepo.existsByMemberId(testMemberId)).isTrue();
+
+        memberRemovalService.removeRelatedPicks(testMemberId);
+
+        assertThat(pickRepo.existsByMemberId(testMemberId)).isFalse();
+    }
+
+    @Test
+    @DisplayName("사용자와 연관된 니즈 수집 질문이 삭제된다.")
+    void removeRelatedInterest() {
+
+        testInitializer.initInterest(testMemberId);
+
+        assertThat(interestRepo.existsById(testMemberId)).isTrue();
+
+        memberRemovalService.removeRelatedInterest(testMemberId);
+
+        assertThat(interestRepo.existsById(testMemberId)).isFalse();
+    }
+}
+
+
+@Component
+@RequiredArgsConstructor
+class MemberRemovalServiceTestInitializer {
+
+    private static final SaveInterestRequest GEN_REQ = new SaveInterestRequest(
+            AgeRange.A_20, LeisureUsual.many, PreferredStyle.relieving,
+            Intensity.light, Theme.earth, AlongWith.alone
+    );
+    private static final List<Long> PICK_LOC_IDS = LongStream.rangeClosed(1, 10).boxed().toList();
+
+    private final MemberRepository memberRepo;
+
+    private final AppleOAuthRepository appleOAuthRepo;
+    private final GoogleOAuthRepository googleOAuthRepo;
+    private final KakaoOAuthRepository kakaoOAuthRepo;
+
+    private final PickRepository pickRepo;
+    private final InterestRepository interestRepo;
+
+    @Transactional
+    public void initOAuths(Long memberId) {
+        Member mem = find(memberId);
+        appleOAuthRepo.save(AppleOAuth.of("apple", mem));
+        googleOAuthRepo.save(GoogleOAuth.of("google", mem));
+        kakaoOAuthRepo.save(KakaoOAuth.of("kakao", mem));
+    }
+
+    @Transactional
+    public void initPicks(Long memberId) {
+        Member mem = find(memberId);
+        PICK_LOC_IDS.stream()
+                .map(id -> Pick.of(mem, id))
+                .forEach(pickRepo::save);
+    }
+
+    @Transactional
+    public void initInterest(Long memberId) {
+        interestRepo.save(
+                Interest.of(find(memberId), InterestInfo.of(GEN_REQ))
+        );
+    }
+
+    private Member find(Long memberId) {
+        return memberRepo.findById(memberId)
+                .orElseThrow();
+    }
+}

--- a/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
+++ b/src/test/java/org/leisureup/member/internal/service/MemberServiceTest.java
@@ -16,13 +16,16 @@ import org.leisureup.member.internal.dto.request.*;
 import org.leisureup.member.internal.dto.request.SaveInterestRequest.*;
 import org.leisureup.member.internal.dto.response.*;
 import org.leisureup.member.internal.repository.*;
+import org.leisureup.member.spi.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.*;
 import org.springframework.test.context.bean.override.mockito.*;
+import org.springframework.test.context.event.*;
 import org.springframework.transaction.annotation.*;
 
 @Slf4j
+@RecordApplicationEvents
 class MemberServiceTest extends IntegrationTestSupport {
 
     private static final Long invalidMemberId = Long.MAX_VALUE;
@@ -34,6 +37,9 @@ class MemberServiceTest extends IntegrationTestSupport {
             .map(MemberServiceTest::locationResponse)
             .toList();
     private static final Long existingLocationId = Long.MAX_VALUE / 2;
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    ApplicationEvents applicationEvents;
     @Autowired
     MemberService service;
     @Autowired
@@ -43,7 +49,7 @@ class MemberServiceTest extends IntegrationTestSupport {
     @Autowired
     PickRepository pickRepo;
     @Autowired
-    TestInitializer testInitializer;
+    MemberServiceTestInitializer testInitializer;
     @MockitoBean
     LocationQueryPort locationQueryPort;
     @MockitoBean
@@ -65,7 +71,9 @@ class MemberServiceTest extends IntegrationTestSupport {
 
     @BeforeEach
     void setUp() {
-        Member save = testInitializer.initializeData(locationIds);
+        applicationEvents.clear();
+
+        Member save = testInitializer.initializePicks(locationIds);
 
         when(locationQueryPort.notExists(anyLong()))
                 .thenAnswer(invocation -> {
@@ -80,7 +88,6 @@ class MemberServiceTest extends IntegrationTestSupport {
                     Long id = invocation.getArgument(0, Long.class);
                     return locationIds.contains(id) || existingLocationId.equals(id);
                 });
-
 
         testMemberId = save.getId();
     }
@@ -107,12 +114,31 @@ class MemberServiceTest extends IntegrationTestSupport {
     }
 
     @Test
+    @DisplayName("어느 사용자를 삭제할 수 있다.")
+    void deleteMember() {
+
+        service.deleteMember(testMemberId);
+
+        assertThat(memberRepo.findById(testMemberId)).isEmpty();
+
+        List<MemberRemovalEvent> publishedEvents
+                = applicationEvents.stream(MemberRemovalEvent.class).toList();
+
+        assertThat(publishedEvents).hasSize(1)
+                .element(0)
+                .satisfies(e -> assertThat(e.memberId()).isEqualTo(testMemberId));
+
+    }
+
+    @Test
     @DisplayName("니즈 수집 질문을 저장한다.")
     void saveInterest() {
 
-        var req = genReq(AgeRange.A_20);
+        var req1 = genReq(AgeRange.A_20);
+        var req2 = genReq(AgeRange.A_30);
+        var expected = InterestInfo.AgeRange.A_30;
 
-        service.saveInterest(testMemberId, req);
+        service.saveInterest(testMemberId, req1);
 
         // 정보가 정상적으로 저장된다.
         assertThat(interestRepo.findById(testMemberId))
@@ -124,6 +150,15 @@ class MemberServiceTest extends IntegrationTestSupport {
 
         assertThat(resp).isNotNull().hasNoNullFieldsOrProperties();
         assertThat(resp.hasAnswered()).isTrue();
+
+        // 다시 저장하면 정보가 수정된다.
+        service.saveInterest(testMemberId, req2);
+
+        assertThat(interestRepo.findById(testMemberId))
+                .isPresent().get()
+                .isNotNull().satisfies(
+                        itr -> assertThat(itr.getInfo().getAgeRange()).isEqualTo(expected)
+                );
     }
 
     @Test
@@ -205,13 +240,13 @@ class MemberServiceTest extends IntegrationTestSupport {
 
 @Component
 @RequiredArgsConstructor
-class TestInitializer {
+class MemberServiceTestInitializer {
 
     private final MemberRepository memberRepo;
     private final PickRepository pickRepo;
 
     @Transactional
-    Member initializeData(List<Long> locationIds) {
+    Member initializePicks(List<Long> locationIds) {
         Member save = memberRepo.save(
                 Member.of("test", "test")
         );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

1. 사용자 삭제 (회원 탈퇴) 기능을 구성했습니다.


## 💬 리뷰 요구사항 (선택)

현재 사용자 삭제시 `연관 계정 정보`, `찜 목록` 만 삭제되고 `Travel` 관련 작업은 진행되지 않습니다.
삭제와 관련된 event DTO `(MemberRemovalEvent.java)` 구성해 두었으니 참고해서 `Travel` 도메인에도 작업 진행해 주세요.