### PR TITLE
Enhance/log-method-io - 메서드 입출력 로깅 추가

### DIFF
--- a/src/main/java/org/leisureup/global/logging/LogMethodIO.java
+++ b/src/main/java/org/leisureup/global/logging/LogMethodIO.java
@@ -1,0 +1,9 @@
+package org.leisureup.global.logging;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogMethodIO {
+
+}

--- a/src/main/java/org/leisureup/global/logging/LogMethodInvocation.java
+++ b/src/main/java/org/leisureup/global/logging/LogMethodInvocation.java
@@ -1,0 +1,9 @@
+package org.leisureup.global.logging;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogMethodInvocation {
+
+}

--- a/src/main/java/org/leisureup/global/logging/LogMethodReturn.java
+++ b/src/main/java/org/leisureup/global/logging/LogMethodReturn.java
@@ -1,0 +1,9 @@
+package org.leisureup.global.logging;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogMethodReturn {
+
+}

--- a/src/main/java/org/leisureup/global/logging/Masked.java
+++ b/src/main/java/org/leisureup/global/logging/Masked.java
@@ -1,0 +1,10 @@
+package org.leisureup.global.logging;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE,
+        ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Masked {
+
+}

--- a/src/main/java/org/leisureup/global/logging/MaskedReturn.java
+++ b/src/main/java/org/leisureup/global/logging/MaskedReturn.java
@@ -1,0 +1,9 @@
+package org.leisureup.global.logging;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MaskedReturn {
+
+}

--- a/src/main/java/org/leisureup/global/logging/aspect/MethodLoggingAspect.java
+++ b/src/main/java/org/leisureup/global/logging/aspect/MethodLoggingAspect.java
@@ -1,0 +1,67 @@
+package org.leisureup.global.logging.aspect;
+
+import java.lang.reflect.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.aspectj.lang.*;
+import org.aspectj.lang.annotation.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class MethodLoggingAspect {
+
+    private final MethodLoggingUtils utils;
+
+    @Pointcut("""
+            @within(org.leisureup.global.logging.LogMethodIO) ||
+            @annotation(org.leisureup.global.logging.LogMethodIO)
+            """)
+    public void logMethodIO() {
+    }
+
+    @Pointcut("""
+            @within(org.leisureup.global.logging.LogMethodInvocation) ||
+            @annotation(org.leisureup.global.logging.LogMethodInvocation)
+            """)
+    public void logMethodInvocation() {
+    }
+
+    @Pointcut("""
+            @within(org.leisureup.global.logging.LogMethodReturn) ||
+            @annotation(org.leisureup.global.logging.LogMethodReturn)
+            """)
+    public void logMethodReturn() {
+    }
+
+    @Before("logMethodIO() || logMethodInvocation()")
+    public void beforeMethodInvocation(JoinPoint joinPoint) {
+        String targetName = joinPoint.getTarget().getClass().getSimpleName();
+
+        Method method = utils.cast(joinPoint);
+        String methodName = method.getName();
+        String methodArgRepresentation = utils.representMethodArguments(
+                method, joinPoint.getArgs()
+        );
+
+        log.info("{}#{} <== {}", targetName, methodName, methodArgRepresentation);
+    }
+
+    @AfterReturning(
+            value = "logMethodIO() || logMethodReturn()",
+            returning = "returnValue"
+    )
+    public void afterMethodReturn(JoinPoint joinPoint, Object returnValue) {
+        String targetName = joinPoint.getTarget().getClass().getSimpleName();
+
+        Method method = utils.cast(joinPoint);
+        String methodName = method.getName();
+        String methodReturnObjRepresentation = utils.representMethodReturnObj(
+                method, returnValue
+        );
+
+        log.info("{}#{} ==> {}", targetName, methodName, methodReturnObjRepresentation);
+    }
+}

--- a/src/main/java/org/leisureup/global/logging/aspect/MethodLoggingUtils.java
+++ b/src/main/java/org/leisureup/global/logging/aspect/MethodLoggingUtils.java
@@ -1,0 +1,188 @@
+package org.leisureup.global.logging.aspect;
+
+import java.lang.reflect.*;
+import java.util.*;
+import lombok.extern.slf4j.*;
+import org.aspectj.lang.*;
+import org.aspectj.lang.reflect.*;
+import org.leisureup.*;
+import org.leisureup.global.logging.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Component
+public class MethodLoggingUtils {
+
+    private static final String MASK_REPRESENTATION = "[*****]";
+    private static final String UNABLE_TO_EXTRACT = "<?>";
+    private static final String BASE_PACKAGE_NAME
+            = LeisureUp.class.getPackage().getName();
+
+    public Method cast(JoinPoint joinPoint) {
+        return ((MethodSignature) joinPoint.getSignature()).getMethod();
+    }
+
+    public String representMethodReturnObj(Method method, Object returnObj) {
+        try {
+            method.setAccessible(true);
+
+            String representation;
+
+            if (isMethodReturnMasked(method)) {
+                representation = MASK_REPRESENTATION;
+            } else {
+                representation = representObj(returnObj);
+            }
+
+            return representation;
+        } catch (Exception e) {
+            log.warn("Failed to log method returns value", e);
+            return UNABLE_TO_EXTRACT;
+        }
+    }
+
+    public String representMethodArguments(Method method, Object[] args) {
+        try {
+            method.setAccessible(true);
+
+            StringBuilder sb = new StringBuilder().append("(");
+
+            Parameter[] parameters = method.getParameters();
+
+            if (parameters.length != args.length) {
+                throw new IllegalArgumentException("Argument & parameter count must same");
+            }
+
+            for (int i = 0; i < args.length; i++) {
+
+                Parameter parameter = parameters[i];
+                Object arg = args[i];
+
+                sb.append(representSingleArg(parameter, arg));
+
+                if (i < parameters.length - 1) {
+                    sb.append(", ");
+                }
+            }
+
+            return sb.append(")").toString();
+        } catch (Exception e) {
+            log.warn("Failed to log method arguments", e);
+            return UNABLE_TO_EXTRACT;
+        }
+    }
+
+    private String representSingleArg(Parameter parameter, Object arg) {
+        String name = parameter.getName();
+        String representation;
+
+        if (isMasked(parameter)) {
+            representation = MASK_REPRESENTATION;
+        } else {
+            representation = representObj(arg);
+        }
+
+        return String.format("%s=%s", name, representation);
+    }
+
+    private boolean isMasked(Parameter parameter) {
+        return Arrays.stream(parameter.getAnnotations())
+                .anyMatch(annotation -> annotation instanceof Masked);
+    }
+
+    private boolean isMasked(Object object) {
+        return Arrays.stream(object.getClass().getAnnotations())
+                .anyMatch(annotation -> annotation instanceof Masked);
+    }
+
+    private boolean isMethodReturnMasked(Method method) {
+        return Arrays.stream(method.getAnnotations())
+                .anyMatch(annotation -> annotation instanceof MaskedReturn);
+    }
+
+    private String representObj(Object obj) {
+
+        if (obj == null) {
+            return "null";
+        }
+
+        // has Masked annotation on class definition?
+        if (isMasked(obj)) {
+            return MASK_REPRESENTATION;
+        }
+
+        if (
+                obj instanceof String || obj instanceof Character ||
+                obj instanceof Number || obj instanceof Boolean ||
+                obj instanceof Enum
+        ) {
+            return obj.toString();
+        }
+
+        if (obj instanceof Collection<?> col) {
+            return col.stream().map(this::representObj)
+                    .toList()
+                    .toString();
+        }
+
+        if (obj instanceof Map<?, ?> map) {
+            Map<String, String> representation = new HashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                String key = representObj(entry.getKey());
+                String value = representObj(entry.getValue());
+                representation.put(key, value);
+            }
+            return representation.toString();
+        }
+
+        if (obj.getClass().isArray()) {
+            int length = Array.getLength(obj);
+            List<String> representation = new ArrayList<>(length);
+            for (int i = 0; i < length; i++) {
+                representation.add(representObj(Array.get(obj, i)));
+            }
+            return representation.toString();
+        }
+
+        // some other complex clazz
+
+        // not our clazz
+        String packageName = obj.getClass().getPackage().getName();
+        if (!packageName.startsWith(BASE_PACKAGE_NAME)) {
+            return obj.toString();
+        }
+
+        StringBuilder sb = new StringBuilder()
+                .append(obj.getClass().getSimpleName())
+                .append("{");
+        Field[] fields = obj.getClass().getDeclaredFields();
+
+        for (int i = 0; i < fields.length; i++) {
+            Field field = fields[i];
+            field.setAccessible(true);
+
+            String name = field.getName();
+            sb.append(name).append("=");
+
+            String valRepresentation;
+
+            if (field.isAnnotationPresent(Masked.class)) {
+                valRepresentation = MASK_REPRESENTATION;
+            } else {
+                try {
+                    valRepresentation = representObj(field.get(obj));
+                } catch (Exception e) {
+                    valRepresentation = UNABLE_TO_EXTRACT;
+                }
+            }
+
+            sb.append(valRepresentation);
+
+            if (i < fields.length - 1) {
+                sb.append(", ");
+            }
+        }
+
+        return sb.append("}").toString();
+    }
+}

--- a/src/main/java/org/leisureup/global/logging/aspect/MethodLoggingUtils.java
+++ b/src/main/java/org/leisureup/global/logging/aspect/MethodLoggingUtils.java
@@ -29,7 +29,8 @@ public class MethodLoggingUtils {
             String representation;
 
             if (isMethodReturnMasked(method)) {
-                representation = MASK_REPRESENTATION;
+                String returnObjClazzName = method.getReturnType().getSimpleName();
+                representation = String.format("%s%s", returnObjClazzName, MASK_REPRESENTATION);
             } else {
                 representation = representObj(returnObj);
             }
@@ -108,7 +109,8 @@ public class MethodLoggingUtils {
 
         // has Masked annotation on class definition?
         if (isMasked(obj)) {
-            return MASK_REPRESENTATION;
+            String clazzName = obj.getClass().getSimpleName();
+            return String.format("%s%s", clazzName, MASK_REPRESENTATION);
         }
 
         if (

--- a/src/main/java/org/leisureup/global/logging/aspect/MethodLoggingUtils.java
+++ b/src/main/java/org/leisureup/global/logging/aspect/MethodLoggingUtils.java
@@ -13,10 +13,15 @@ import org.springframework.stereotype.*;
 @Component
 public class MethodLoggingUtils {
 
+    private static final String VISITED = "<VISITED>";
     private static final String MASK_REPRESENTATION = "[*****]";
     private static final String UNABLE_TO_EXTRACT = "<?>";
     private static final String BASE_PACKAGE_NAME
             = LeisureUp.class.getPackage().getName();
+
+    private static Set<Integer> getNewSet() {
+        return new HashSet<>();
+    }
 
     public Method cast(JoinPoint joinPoint) {
         return ((MethodSignature) joinPoint.getSignature()).getMethod();
@@ -32,11 +37,11 @@ public class MethodLoggingUtils {
                 String returnObjClazzName = method.getReturnType().getSimpleName();
                 representation = String.format("%s%s", returnObjClazzName, MASK_REPRESENTATION);
             } else {
-                representation = representObj(returnObj);
+                representation = representObj(returnObj, getNewSet());
             }
 
             return representation;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.warn("Failed to log method returns value", e);
             return UNABLE_TO_EXTRACT;
         }
@@ -67,7 +72,7 @@ public class MethodLoggingUtils {
             }
 
             return sb.append(")").toString();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.warn("Failed to log method arguments", e);
             return UNABLE_TO_EXTRACT;
         }
@@ -80,7 +85,7 @@ public class MethodLoggingUtils {
         if (isMasked(parameter)) {
             representation = MASK_REPRESENTATION;
         } else {
-            representation = representObj(arg);
+            representation = representObj(arg, getNewSet());
         }
 
         return String.format("%s=%s", name, representation);
@@ -101,7 +106,7 @@ public class MethodLoggingUtils {
                 .anyMatch(annotation -> annotation instanceof MaskedReturn);
     }
 
-    private String representObj(Object obj) {
+    private String representObj(Object obj, Set<Integer> visited) {
 
         if (obj == null) {
             return "null";
@@ -122,7 +127,7 @@ public class MethodLoggingUtils {
         }
 
         if (obj instanceof Collection<?> col) {
-            return col.stream().map(this::representObj)
+            return col.stream().map(c -> representObj(c, visited))
                     .toList()
                     .toString();
         }
@@ -130,8 +135,8 @@ public class MethodLoggingUtils {
         if (obj instanceof Map<?, ?> map) {
             Map<String, String> representation = new HashMap<>();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
-                String key = representObj(entry.getKey());
-                String value = representObj(entry.getValue());
+                String key = representObj(entry.getKey(), visited);
+                String value = representObj(entry.getValue(), visited);
                 representation.put(key, value);
             }
             return representation.toString();
@@ -141,7 +146,7 @@ public class MethodLoggingUtils {
             int length = Array.getLength(obj);
             List<String> representation = new ArrayList<>(length);
             for (int i = 0; i < length; i++) {
-                representation.add(representObj(Array.get(obj, i)));
+                representation.add(representObj(Array.get(obj, i), visited));
             }
             return representation.toString();
         }
@@ -154,6 +159,19 @@ public class MethodLoggingUtils {
             return obj.toString();
         }
 
+        int identityHashCode = System.identityHashCode(obj);
+
+        // visisted obj
+        if (!visited.add(identityHashCode)) {
+            String clazzName = obj.getClass().getSimpleName();
+            log.warn(
+                    "Circular reference detected for [{}@{}]. Truncating representation.",
+                    clazzName, obj.hashCode()
+            );
+            return String.format("%s@%s%s", clazzName, obj.hashCode(), VISITED);
+        }
+
+        // our clazz
         StringBuilder sb = new StringBuilder()
                 .append(obj.getClass().getSimpleName())
                 .append("{");
@@ -172,8 +190,8 @@ public class MethodLoggingUtils {
                 valRepresentation = MASK_REPRESENTATION;
             } else {
                 try {
-                    valRepresentation = representObj(field.get(obj));
-                } catch (Exception e) {
+                    valRepresentation = representObj(field.get(obj), visited);
+                } catch (Throwable e) {
                     valRepresentation = UNABLE_TO_EXTRACT;
                 }
             }

--- a/src/main/java/org/leisureup/location/spi/internal/CategorySpiImpl.java
+++ b/src/main/java/org/leisureup/location/spi/internal/CategorySpiImpl.java
@@ -1,11 +1,12 @@
 package org.leisureup.location.spi.internal;
 
 import java.util.*;
-import java.util.function.*;
 import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.stream.*;
 import lombok.*;
 import org.leisureup.global.exception.*;
+import org.leisureup.global.logging.*;
 import org.leisureup.location.internal.domain.*;
 import org.leisureup.location.internal.domain.AdditionalCategoryInfo.*;
 import org.leisureup.location.internal.repository.*;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.*;
 import org.springframework.stereotype.*;
 
 @Component
+@LogMethodIO
 @RequiredArgsConstructor
 public class CategorySpiImpl implements CategorySpi {
 

--- a/src/main/java/org/leisureup/location/spi/internal/LocationFetchSpiImpl.java
+++ b/src/main/java/org/leisureup/location/spi/internal/LocationFetchSpiImpl.java
@@ -4,6 +4,7 @@ import jakarta.validation.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
 import org.leisureup.global.exception.*;
+import org.leisureup.global.logging.*;
 import org.leisureup.location.internal.repository.*;
 import org.leisureup.location.internal.service.*;
 import org.leisureup.location.spi.*;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.*;
 
 @Slf4j
 @Component
+@LogMethodIO
 @RequiredArgsConstructor
 public class LocationFetchSpiImpl implements LocationFetchSpi {
 

--- a/src/main/java/org/leisureup/location/spi/internal/LocationQueryAdapter.java
+++ b/src/main/java/org/leisureup/location/spi/internal/LocationQueryAdapter.java
@@ -7,6 +7,7 @@ import java.util.stream.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
 import org.leisureup.global.exception.*;
+import org.leisureup.global.logging.*;
 import org.leisureup.location.internal.domain.*;
 import org.leisureup.location.internal.repository.*;
 import org.leisureup.location.spi.*;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.*;
 
 @Slf4j
 @Component
+@LogMethodIO
 @RequiredArgsConstructor
 public class LocationQueryAdapter implements LocationQueryPort {
 

--- a/src/main/java/org/leisureup/travel/internal/travel/controller/TravelController.java
+++ b/src/main/java/org/leisureup/travel/internal/travel/controller/TravelController.java
@@ -1,18 +1,16 @@
 package org.leisureup.travel.internal.travel.controller;
 
-import lombok.RequiredArgsConstructor;
-import org.leisureup.global.AuthHolder;
-import org.leisureup.global.JwtAuthRequired;
-import org.leisureup.global.response.ApiResponse;
-import org.leisureup.travel.internal.travel.dto.request.AddItemRequest;
-import org.leisureup.travel.internal.travel.dto.request.CreateTravelRequest;
-import org.leisureup.travel.internal.travel.dto.response.GetAllTravelResponse;
-import org.leisureup.travel.internal.travel.dto.response.GetTravelDetailResponse;
-import org.leisureup.travel.internal.travel.service.TravelService;
+import java.util.*;
+import lombok.*;
+import org.leisureup.global.*;
+import org.leisureup.global.logging.*;
+import org.leisureup.global.response.*;
+import org.leisureup.travel.internal.travel.dto.request.*;
+import org.leisureup.travel.internal.travel.dto.response.*;
+import org.leisureup.travel.internal.travel.service.*;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
+@LogMethodInvocation
 @RestController
 @RequiredArgsConstructor
 @JwtAuthRequired

--- a/src/main/java/org/leisureup/travel/internal/travel/service/TravelService.java
+++ b/src/main/java/org/leisureup/travel/internal/travel/service/TravelService.java
@@ -5,6 +5,7 @@ import java.util.function.*;
 import java.util.stream.*;
 import lombok.*;
 import org.leisureup.global.exception.*;
+import org.leisureup.global.logging.*;
 import org.leisureup.global.response.*;
 import org.leisureup.location.spi.*;
 import org.leisureup.travel.internal.travel.domain.*;
@@ -15,6 +16,7 @@ import org.springframework.context.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
 
+@LogMethodIO
 @Service
 @RequiredArgsConstructor
 public class TravelService {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

`None`

## 📝작업 내용

에러 추적에 불편함을 느껴 메서드 호출, 반환값에 대한 로깅을 구성했습니다.

1. `@LogMethodInvocation`, `@LogMethodReturn`, `@LogMethodIO` 로 메서드 arguments, return value 를 로깅할 수 있습니다.
  - 클래스에 붙이면 속한 모든 메서드에 적용됩니다.
  - `@LogMethodInvocation` 는 `메서드 arguments 로깅` 을 활성화합니다.
  - `@LogMethodReturn` 는 `메서드 return value 로깅` 을 활성화합니다.
  - `@LogMethodIO` 는 둘다 활성화 합니다.

2. `@Masked`, `@MaskedReturn` 를 통해 민감 정보는 가린채 로깅할 수 있습니다.
- `메서드 arguments 로깅` 시 parameter 에 `@Masked` 를 정의해 해당 param 내용을 가릴 수 있습니다.
- `메서드 return value 로깅` 시 메서드 정의에 `@MaskedReturn` 을 통해 return 값 내용을 가릴 수 있습니다.

예시

```java
@LogMethodInvocation
public void logMethodArgs(Long id, @Masked String secret)   {
    /* ... */
}

@MaskedReturn
@LogMethodReturn
public Object logMethodReturn() {
    return new Object();
}
```

```java
record ReturnObj(
        Long id,
        @Masked
        String secret
) {

}

@LogMethodIO
@RestController
static class Test {

    @GetMapping("/test")
    public ApiResponse<ReturnObj> test(Long id, @Masked String secret) {
        return ApiResponse.success(200, new ReturnObj(id, secret));
    }

}
```

```log
2025-09-03T02:39:17.735KST [RID: 0c1f-1147] [TID:          ]  INFO 23060 --- [LeisureUp-BE] [omcat-handler-5] o.l.g.l.aspect.MethodLoggingAspect       : Test#test <== (id=10, secret=[*****])
2025-09-03T02:39:17.737KST [RID: 0c1f-1147] [TID:          ]  INFO 23060 --- [LeisureUp-BE] [omcat-handler-5] o.l.g.l.aspect.MethodLoggingAspect       : Test#test ==> ApiResponse{success=true, code=200, data=ReturnObj{id=10, secret=[*****]}, message=null, requestId=null}
```

## 💬 리뷰 요구사항 (선택)

`None`